### PR TITLE
fix(risk-scorer): persist interrupt_agent completions

### DIFF
--- a/.changeset/bright-close-bridge.md
+++ b/.changeset/bright-close-bridge.md
@@ -1,0 +1,5 @@
+---
+"@windyroad/risk-scorer": patch
+---
+
+Recognize Codex's current `interrupt_agent` completion event so pipeline risk receipts persist for the assessed checkout.

--- a/docs/problems/open/461-downstream-evidence-scan-flags-stale-install-sightings-as-live-regressions.md
+++ b/docs/problems/open/461-downstream-evidence-scan-flags-stale-install-sightings-as-live-regressions.md
@@ -16,7 +16,18 @@ When mining adopter-repo transcripts for evidence (the `/wr-itil:review-problems
 
 Concrete cost, 2026-07-25 (this session): the downstream-scan flagged P281 (capture-problem flat-path) and P365 (external-comms private-repo commit) as "still recurring in adopters" based on addressr/voder-mcp-hub transcript sightings. Both were flipped from Verifying → Known Error on that signal. On verification, the current source is CLEAN for both (P281 writes per-state + auto-migrates; P365 has the repo-visibility precondition) — the sightings were stale adopter installs (voder explicitly on itil 0.35.6, months behind). Both had to be flipped back to Verifying. The two wrong transitions were avoidable with a version-gate.
 
-Same root as the appetite-semantics observation left in this session (adopters silently run stale plugin semantics) — but this ticket is specifically about the **evidence-mining method** over-flagging, not the runtime stale-semantics itself.
+Same root as the appetite-semantics observation left in this session (adopters silently run stale plugin semantics) — but this ticket is specifically about the **evidence-mining method** over-flagging, not the runtime stale-semantics itself. The relevance gate is symmetric: later unrelated upstream state also cannot invalidate an exact supported-installed artifact whose required downstream behavior remains applicable.
+
+### Recurrence: unrelated later upstream CI was propagated downstream (2026-08-12)
+
+A downstream delivery was incorrectly frozen because later `agent-plugins` main CI exhausted a shared Claude OAuth quota, even though the supported-installed risk-scorer artifact contained the required cwd-binding repair. The maintainer corrected the dependency boundary:
+
+- downstream truth is scoped to the exact supported-installed artifact and the relevant behavior in the actual delivery checkout;
+- commit, push, and release risk score the real change set at their respective delivery stages in that checkout;
+- a separate clone/worktree is workspace hygiene, not a distinct scoring subject or prerequisite consumer rehearsal;
+- later unrelated upstream CI does not freeze or rewind a downstream consumer unless it invalidates the consumed artifact or its required behavior.
+
+The Claude Agent-Prose failure remained an `agent-plugins` release-quality concern. It did not invalidate the supported-installed risk-scorer artifact or make latest upstream `main` green a downstream delivery dependency. The correct recovery was to resume the consumer's normal score/gate flow in its existing checkout, not wait for unrelated CI or invent a synthetic installed-package rehearsal.
 
 ## Symptoms
 
@@ -27,6 +38,8 @@ Same root as the appetite-semantics observation left in this session (adopters s
 ## Workaround
 
 Before treating an adopter-repo sighting as a live regression, verify the fix's presence in **current source** AND, where determinable, the adopter's **installed plugin version** vs the fix release. If current source is clean, the sighting is a stale-install artifact — do not reopen; keep/return to Verifying.
+
+Before blocking a downstream consumer on later upstream evidence, bind the evidence to the exact artifact/version the consumer uses and the required behavior. If the later failure is unrelated, preserve the downstream boundary and evaluate the normal delivery path in its actual checkout.
 
 ## Impact Assessment
 
@@ -44,8 +57,9 @@ The downstream-scan method (and the sub-agents that implement it) treat "bug sig
 ### Investigation Tasks
 
 - [ ] Add a version-gate step to the downstream-scan contract in `/wr-itil:review-problems` (and the evidence-mining sub-agent prompts): source-clean OR adopter-version ≥ fix-release before a regression verdict
+- [ ] Make the relevance gate symmetric: unrelated later upstream CI cannot block or rewind a downstream dependency whose exact consumed artifact remains valid; do not add an independent-clone smoke as a prerequisite for the normal checkout-scoped delivery gate
 - [ ] Decide whether adopter installed-version is determinable from transcripts (plugin cache paths carry versions) or must be assumed-stale
-- [ ] Behavioural coverage for the "stale-install sighting → NOT a regression" path
+- [ ] Behavioural coverage for both directions: stale-install sighting → NOT a regression; unrelated later upstream failure → NOT a downstream block
 
 ## Dependencies
 

--- a/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
+++ b/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
@@ -1,0 +1,36 @@
+# Problem 477: Codex `interrupt_agent` completion bypasses the risk-marker bridge
+
+**Status**: Open
+**Reported**: 2026-08-12
+**Priority**: 20 (Very High) — Impact: 4 × Likelihood: 5
+**Origin**: internal
+**Effort**: S
+**JTBD**: JTBD-001
+**Persona**: plugin-developer
+
+## Description
+
+The supported-installed risk scorer tells Codex to close a completed pipeline agent with `interrupt_agent`, but its hook matcher, dispatcher, and completion bridge do not recognize that current tool name. They recognize legacy and older close names only. The scorer returns the correct `RISK_SCORES` and `RISK_CWD`, but marker persistence never runs, so the normal commit gate remains bound to stale or missing state.
+
+The direct downstream witness scored its actual delivery checkout correctly, then produced no new checkout-bound marker after `interrupt_agent`. No commit, bypass, or external-system mutation occurred.
+
+## Workaround
+
+None. Do not hand-edit markers or bypass hooks. Install the repaired package, rerun the scorer in the actual delivery checkout, and close the completed agent normally.
+
+## Root Cause Analysis
+
+The runtime changed its unqualified completed-agent tool name from the bridge's recognized variants to `interrupt_agent`. The skill contract was updated to use that name, but the three runtime routing lists and behavioral fixture were not updated with it.
+
+## Fix and Verification
+
+- Add `interrupt_agent` to the PostToolUse matcher, dispatcher, and completion bridge close-name set.
+- Reproduce the exact `spawn_agent` response plus `interrupt_agent` completion payload.
+- Assert scores and opaque checkout identity persist for `RISK_CWD`, not the task root.
+- Release and supported-install the patch before the downstream consumer retries its normal gate.
+
+No ADR is required: this restores the already-intended completed-agent compatibility path without changing the scoring or delivery contract.
+
+## Related
+
+- P461 — separate evidence-boundary correction; not the runtime defect fixed here.

--- a/packages/risk-scorer/hooks/codex-agent-completion.mjs
+++ b/packages/risk-scorer/hooks/codex-agent-completion.mjs
@@ -171,7 +171,7 @@ if (!/^[A-Za-z0-9-]+$/.test(input.session_id || "")) process.exit(0);
 if (["collaborationspawn_agent", "spawn_agent", "multi_agent_v1__spawn_agent"].includes(input.tool_name)) {
   rememberSpawn(input);
 }
-if (["collaborationinterrupt_agent", "close_agent", "multi_agent_v1__close_agent"].includes(input.tool_name)) {
+if (["collaborationinterrupt_agent", "interrupt_agent", "close_agent", "multi_agent_v1__close_agent"].includes(input.tool_name)) {
   markClose(input);
 }
 if (["collaborationwait_agent", "wait_agent", "multi_agent_v1__wait_agent"].includes(input.tool_name)) {

--- a/packages/risk-scorer/hooks/hooks.json
+++ b/packages/risk-scorer/hooks/hooks.json
@@ -10,7 +10,7 @@
       { "matcher": "Bash|Edit|Write|ExitPlanMode|EnterPlanMode", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/risk-scorer-dispatch.sh pre-tool" }] }
     ],
     "PostToolUse": [
-      { "matcher": "Agent|Bash|Edit|Skill|Write|collaborationspawn_agent|collaborationwait_agent|collaborationinterrupt_agent|spawn_agent|wait_agent|close_agent|multi_agent_v1__spawn_agent|multi_agent_v1__wait_agent|multi_agent_v1__close_agent", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/risk-scorer-dispatch.sh post-tool" }] }
+      { "matcher": "Agent|Bash|Edit|Skill|Write|collaborationspawn_agent|collaborationwait_agent|collaborationinterrupt_agent|spawn_agent|wait_agent|interrupt_agent|close_agent|multi_agent_v1__spawn_agent|multi_agent_v1__wait_agent|multi_agent_v1__close_agent", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/risk-scorer-dispatch.sh post-tool" }] }
     ],
     "SubagentStop": [
       { "matcher": "^wr-risk-scorer:", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/risk-scorer-dispatch.sh subagent-stop" }] }

--- a/packages/risk-scorer/hooks/risk-scorer-dispatch.sh
+++ b/packages/risk-scorer/hooks/risk-scorer-dispatch.sh
@@ -77,7 +77,7 @@ if messages:
         run_hook risk-score-mark.sh
         run_hook risk-slide-marker.sh
         ;;
-      collaborationspawn_agent|collaborationwait_agent|collaborationinterrupt_agent|spawn_agent|wait_agent|close_agent|multi_agent_v1__spawn_agent|multi_agent_v1__wait_agent|multi_agent_v1__close_agent)
+      collaborationspawn_agent|collaborationwait_agent|collaborationinterrupt_agent|spawn_agent|wait_agent|interrupt_agent|close_agent|multi_agent_v1__spawn_agent|multi_agent_v1__wait_agent|multi_agent_v1__close_agent)
         printf '%s' "$INPUT" | node "$SCRIPT_DIR/codex-agent-completion.mjs"
         ;;
       Bash)

--- a/packages/risk-scorer/hooks/test/codex-agent-completion.bats
+++ b/packages/risk-scorer/hooks/test/codex-agent-completion.bats
@@ -42,6 +42,11 @@ current_spawn_input() {
     "$SESSION" "$TMP" "${1:-wr-risk-scorer:external-comms}" "$TARGET"
 }
 
+direct_spawn_input() {
+  printf '{"session_id":"%s","cwd":"%s","tool_name":"spawn_agent","tool_input":{"agent_type":"%s"},"tool_response":{"task_name":"%s"}}' \
+    "$SESSION" "$TMP" "${1:-wr-risk-scorer:external-comms}" "$TARGET"
+}
+
 close_input() {
   printf '{"session_id":"%s","cwd":"%s","tool_name":"collaborationinterrupt_agent","tool_input":{"target":"%s"},"tool_response":"{\\"previous_status\\":{\\"completed\\":\\"EXTERNAL_COMMS_RISK_VERDICT: PASS\\\\nEXTERNAL_COMMS_RISK_KEY: %s\\"}}"}' \
     "$SESSION" "$TMP" "$TARGET" "$KEY"
@@ -59,6 +64,11 @@ current_pipeline_wait_input() {
 
 current_pipeline_close_input() {
   printf '{"session_id":"%s","cwd":"%s","tool_name":"multi_agent_v1__close_agent","tool_input":{"target":"%s"},"tool_response":{"previous_status":{"completed":"RISK_SCORES: commit=4 push=4 release=4\\nRISK_CWD: %s"}}}' \
+    "$SESSION" "$OTHER_REPO" "$TARGET" "$PIPELINE_REPO"
+}
+
+direct_pipeline_interrupt_input() {
+  printf '{"session_id":"%s","cwd":"%s","tool_name":"interrupt_agent","tool_input":{"target":"%s"},"tool_response":{"previous_status":{"completed":"RISK_SCORES: commit=4 push=4 release=4\\nRISK_CWD: %s"}}}' \
     "$SESSION" "$OTHER_REPO" "$TARGET" "$PIPELINE_REPO"
 }
 
@@ -99,6 +109,27 @@ subagent_stop_input() {
   dispatch "$(current_close_input)"
 
   [ -f "$TMPDIR/claude-risk-$SESSION/external-comms-risk-reviewed-$KEY" ]
+}
+
+@test "direct Codex interrupt_agent completion persists the assessed checkout" {
+  dispatch "$(direct_spawn_input wr-risk-scorer:pipeline)"
+  dispatch "$(direct_pipeline_interrupt_input)"
+
+  rdir="$TMPDIR/claude-risk-$SESSION"
+  [ "$(cat "$rdir/commit")" = "4" ]
+  expected_checkout="$(cd "$PIPELINE_REPO" && source "$HOOK_DIR/lib/gate-helpers.sh" && _checkout_id)"
+  completion_checkout="$(cd "$OTHER_REPO" && source "$HOOK_DIR/lib/gate-helpers.sh" && _checkout_id)"
+  [ "$(cat "$rdir/checkout-id")" = "$expected_checkout" ]
+  [ "$expected_checkout" != "$completion_checkout" ]
+  [ ! -e "$OTHER_REPO/.risk-reports" ]
+}
+
+@test "PostToolUse routes direct Codex interrupt_agent completions" {
+  run node -e '
+    const hooks = require(process.argv[1]).hooks.PostToolUse;
+    if (!hooks.some(({ matcher }) => matcher.split("|").includes("interrupt_agent"))) process.exit(1);
+  ' "$HOOK_DIR/hooks.json"
+  [ "$status" -eq 0 ]
 }
 
 @test "current wait response stays inert until completed-agent close" {


### PR DESCRIPTION
## Summary
- recognize Codex's current `interrupt_agent` completed-agent event in hook registration, dispatch, and receipt persistence
- preserve existing `RISK_CWD` validation and bind markers to the assessed checkout
- record the direct runtime defect and corrected downstream dependency boundary

## Verification
- focused completion bridge: 11/11
- complete risk-scorer hook suite: 218/218
- Codex packaging suite: 9/9
- package dry-run includes the corrected runtime files
- active installed containment persisted commit/push/release markers for `RISK_CWD` and left the task root untouched

This is supported package follow-up to locally verified incident containment. It adds no hook, dependency, external-system mutation, evaluator waiver, or scoring-contract change.
