### PR TITLE
fix(risk-scorer): bridge child completion receipts

### DIFF
--- a/.changeset/close-child-risk-receipt.md
+++ b/.changeset/close-child-risk-receipt.md
@@ -1,0 +1,5 @@
+---
+"@windyroad/risk-scorer": patch
+---
+
+Persist Codex pipeline risk receipts when native collaboration completion is observed only in the child conversation.

--- a/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
+++ b/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
@@ -1,4 +1,4 @@
-# Problem 477: Codex `interrupt_agent` completion bypasses the risk-marker bridge
+# Problem 477: Codex collaboration completion bypasses the risk-marker bridge
 
 **Status**: Open
 **Reported**: 2026-08-12
@@ -10,7 +10,7 @@
 
 ## Description
 
-The supported-installed risk scorer tells Codex to close a completed pipeline agent with `interrupt_agent`, but its hook matcher, dispatcher, and completion bridge do not recognize that current tool name. They recognize legacy and older close names only. The scorer returns the correct `RISK_SCORES` and `RISK_CWD`, but marker persistence never runs, so the normal commit gate remains bound to stale or missing state.
+The supported-installed risk scorer tells Codex to close a completed pipeline agent with `interrupt_agent`. Version 0.18.10 recognizes that tool name, but current native collaboration calls do not emit the expected parent `PostToolUse` event. `SubagentStop` arrives in the child conversation without the parent's spawn-state record. The scorer returns the correct `RISK_SCORES` and `RISK_CWD`, but marker persistence never runs, so the normal commit gate remains bound to stale or missing state.
 
 The direct downstream witness scored its actual delivery checkout correctly, then produced no new checkout-bound marker after `interrupt_agent`. No commit, bypass, or external-system mutation occurred.
 
@@ -20,16 +20,17 @@ None. Do not hand-edit markers or bypass hooks. Install the repaired package, re
 
 ## Root Cause Analysis
 
-The runtime changed its unqualified completed-agent tool name from the bridge's recognized variants to `interrupt_agent`. The skill contract was updated to use that name, but the three runtime routing lists and behavioral fixture were not updated with it.
+The bridge assumed every native collaboration spawn and close would be observable in the parent session. Current Codex emits the child `SubagentStop`, but not the parent `PostToolUse` events needed to create and consume that session-local role state. Code-mode execution also lacks a parent `PreToolUse` event, so the handoff must survive until the next already-enabled parent prompt. Adding the current close name in 0.18.10 fixed routing only where those parent events exist; it did not repair the missing event boundary.
 
 ## Fix and Verification
 
-- Add `interrupt_agent` to the PostToolUse matcher, dispatcher, and completion bridge close-name set.
-- Reproduce the exact `spawn_agent` response plus `interrupt_agent` completion payload.
-- Assert scores and opaque checkout identity persist for `RISK_CWD`, not the task root.
+- On a risk-scorer `SubagentStop` without spawn state, publish a short-lived sanitized receipt bound to the exact physical checkout and pipeline state hash.
+- On the existing parent `PreToolUse:Bash` path, or the next `UserPromptSubmit` when code mode exposes no tool event, atomically claim the matching receipt and pass it to the existing marker writer under the parent's real session.
+- Reproduce distinct child/parent sessions with no spawn-state file and assert scores, state hash, and opaque checkout identity persist only for the assessed checkout.
+- Reject malformed output, invalid roots, checkout drift, expired receipts, and duplicate completion without persisting an absolute path.
 - Release and supported-install the patch before the downstream consumer retries its normal gate.
 
-No ADR is required: this restores the already-intended completed-agent compatibility path without changing the scoring or delivery contract.
+No new hook or ADR is required: this restores the intended completed-agent compatibility path using the already-enabled `SubagentStop`, `PreToolUse:Bash`, and `UserPromptSubmit` events without changing the scoring or delivery contract.
 
 ## Related
 

--- a/packages/risk-scorer/hooks/codex-agent-completion.mjs
+++ b/packages/risk-scorer/hooks/codex-agent-completion.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -26,6 +27,10 @@ function response(input) {
 
 function riskDir(sessionId) {
   return join(process.env.TMPDIR || "/tmp", `claude-risk-${sessionId}`);
+}
+
+function pendingDir() {
+  return join(process.env.TMPDIR || "/tmp", "claude-risk-pending");
 }
 
 function statePath(input, target, suffix = "") {
@@ -98,6 +103,63 @@ function pipelineAssessment(output) {
   return { root, output: sanitized };
 }
 
+function checkoutId(root) {
+  const stat = statSync(root);
+  return createHash("sha256").update(`${stat.dev}:${stat.ino}`).digest("hex");
+}
+
+function stateHash(root) {
+  const state = spawnSync(join(hookDir, "lib/pipeline-state.sh"), ["--hash-inputs"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (state.status !== 0) return null;
+  return createHash("md5").update(state.stdout).digest("hex");
+}
+
+function completionId(input, output) {
+  if (typeof input.session_id !== "string" || typeof input.agent_id !== "string") return null;
+  return createHash("sha256").update(`${input.session_id}\0${input.agent_id}\0${output}`).digest("hex");
+}
+
+function pendingPath(id, hash, completion, suffix = "") {
+  return join(pendingDir(), `${id}-${hash}-${completion}${suffix}`);
+}
+
+function freshReceipt(path) {
+  if (!existsSync(path)) return false;
+  const ttl = Number.parseInt(process.env.RISK_TTL || "3600", 10) * 1000;
+  return Date.now() - statSync(path).mtimeMs < ttl;
+}
+
+function persistPendingPipeline(input) {
+  if (input.agent_type !== "wr-risk-scorer:pipeline") return;
+  const assessment = pipelineAssessment(input.last_assistant_message);
+  if (!assessment) return;
+  const id = checkoutId(assessment.root);
+  const hash = stateHash(assessment.root);
+  const completion = completionId(input, assessment.output);
+  if (!hash || !completion || !/^RISK_SCORES: commit=\d+ push=\d+ release=\d+$/m.test(assessment.output)) return;
+  mkdirSync(pendingDir(), { recursive: true });
+  const path = pendingPath(id, hash, completion);
+  for (const candidate of [path, `${path}.done`]) {
+    if (freshReceipt(candidate)) return;
+    rmSync(candidate, { force: true });
+  }
+  try {
+    writeFileSync(path, JSON.stringify({
+      role: input.agent_type,
+      output: assessment.output,
+      checkoutId: id,
+      stateHash: hash,
+      completionId: completion,
+      createdAt: Date.now(),
+    }), { flag: "wx", mode: 0o600 });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
 function markTarget(input, target, output) {
   if (typeof target !== "string" || typeof output !== "string" || !output) return;
 
@@ -152,7 +214,88 @@ function markWait(input) {
 }
 
 function markSubagentStop(input) {
-  markTarget(input, input.agent_id, input.last_assistant_message);
+  const state = typeof input.agent_id === "string" ? statePath(input, input.agent_id) : "";
+  if (state && existsSync(state)) {
+    markTarget(input, input.agent_id, input.last_assistant_message);
+    return;
+  }
+  persistPendingPipeline(input);
+}
+
+function consumePending(input) {
+  if (!/^[A-Za-z0-9-]+$/.test(input.session_id || "")) return;
+  let root;
+  try {
+    root = realpathSync(process.cwd());
+  } catch {
+    return;
+  }
+  const git = spawnSync("git", ["-C", root, "rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (git.status !== 0 || realpathSync(git.stdout.trim()) !== root) return;
+
+  const id = checkoutId(root);
+  const hash = stateHash(root);
+  if (!hash) return;
+  const prefix = `${id}-${hash}-`;
+  const pendingPaths = existsSync(pendingDir())
+    ? readdirSync(pendingDir())
+      .filter((name) => name.startsWith(prefix) && !name.endsWith(".claim") && !name.endsWith(".done"))
+      .map((name) => join(pendingDir(), name))
+      .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
+    : [];
+  const path = pendingPaths[0];
+  if (!path) return;
+
+  const claim = `${path}.claim`;
+  try {
+    writeFileSync(claim, "", { flag: "wx", mode: 0o600 });
+  } catch (error) {
+    if (error?.code === "EEXIST") return;
+    throw error;
+  }
+
+  try {
+    const pending = JSON.parse(readFileSync(path, "utf8"));
+    const ttl = Number.parseInt(process.env.RISK_TTL || "3600", 10) * 1000;
+    if (pending.role !== "wr-risk-scorer:pipeline" || pending.checkoutId !== id ||
+        pending.stateHash !== hash || typeof pending.output !== "string" ||
+        typeof pending.completionId !== "string" || !path.endsWith(`-${pending.completionId}`) ||
+        !Number.isFinite(pending.createdAt) || Date.now() - pending.createdAt < 0 ||
+        Date.now() - pending.createdAt >= ttl) return;
+
+    const synthetic = {
+      ...input,
+      cwd: root,
+      tool_name: "Agent",
+      tool_input: { subagent_type: pending.role, prompt: "" },
+      tool_response: { content: [{ type: "text", text: pending.output }] },
+    };
+    const result = spawnSync(join(hookDir, "risk-score-mark.sh"), {
+      cwd: root,
+      env: process.env,
+      input: JSON.stringify(synthetic),
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      process.exitCode = 1;
+      return;
+    }
+    const assessedAt = new Date(pending.createdAt);
+    const markers = ["commit", "push", "release", "commit-born", "push-born", "release-born"];
+    if (/^RISK_BYPASS:\s*reducing\s*$/m.test(pending.output)) {
+      markers.push("reducing-commit", "reducing-push", "reducing-release");
+    } else if (/^RISK_BYPASS:\s*incident\s*$/m.test(pending.output)) {
+      markers.push("incident-release");
+    }
+    for (const marker of markers) {
+      const markerPath = join(riskDir(input.session_id), marker);
+      if (existsSync(markerPath)) utimesSync(markerPath, assessedAt, assessedAt);
+    }
+    renameSync(path, `${path}.done`);
+    for (const stale of pendingPaths.slice(1)) rmSync(stale, { force: true });
+  } finally {
+    rmSync(claim, { force: true });
+  }
 }
 
 let body = "";
@@ -164,6 +307,11 @@ try {
   input = JSON.parse(body);
 } catch {
   process.exit(0);
+}
+
+if (process.argv.includes("--consume-pending")) {
+  consumePending(input);
+  process.exit(process.exitCode || 0);
 }
 
 if (!/^[A-Za-z0-9-]+$/.test(input.session_id || "")) process.exit(0);

--- a/packages/risk-scorer/hooks/risk-pending-receipt.sh
+++ b/packages/risk-scorer/hooks/risk-pending-receipt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Consume a checkout-bound Codex SubagentStop receipt in the parent session.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/gate-helpers.sh"
+_parse_input
+
+TOOL_NAME="$(_get_tool_name)"
+EVENT_NAME="$(printf '%s' "$_HOOK_INPUT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("hook_event_name", ""))' 2>/dev/null || true)"
+[ "$TOOL_NAME" = "Bash" ] || [ "$EVENT_NAME" = "UserPromptSubmit" ] || exit 0
+_enter_hook_cwd || exit 0
+printf '%s' "$_HOOK_INPUT" | node "$SCRIPT_DIR/codex-agent-completion.mjs" --consume-pending

--- a/packages/risk-scorer/hooks/risk-scorer-dispatch.sh
+++ b/packages/risk-scorer/hooks/risk-scorer-dispatch.sh
@@ -47,6 +47,9 @@ if messages:
     fi
     ;;
   user-prompt)
+    # Codex code-mode tools do not expose a parent PreToolUse event. Import a
+    # completed child receipt on the next already-enabled parent prompt.
+    "$SCRIPT_DIR/risk-pending-receipt.sh" <<<"$INPUT" || true
     run_hook risk-score.sh
     run_hook staleness-check.sh
     ;;
@@ -59,6 +62,10 @@ if messages:
         run_hook risk-policy-enforce-edit.sh
         ;;
       Bash)
+        # Current Codex emits SubagentStop in the child conversation but does
+        # not expose native collaboration calls to the parent's PostToolUse.
+        # Import the exact checkout/hash-bound receipt before enforcing gates.
+        "$SCRIPT_DIR/risk-pending-receipt.sh" <<<"$INPUT" || true
         run_hook git-push-gate.sh
         run_hook risk-score-commit-gate.sh
         run_hook external-comms-gate.sh

--- a/packages/risk-scorer/hooks/test/codex-agent-completion.bats
+++ b/packages/risk-scorer/hooks/test/codex-agent-completion.bats
@@ -18,6 +18,7 @@ setup() {
   git -C "$OTHER_REPO" add state
   git -C "$PIPELINE_REPO" -c user.name=test -c user.email=test@example.com commit -qm initial
   git -C "$OTHER_REPO" -c user.name=test -c user.email=test@example.com commit -qm initial
+  printf '# Risk Policy\n\n## Risk Appetite\n\n**Threshold: 5 (Low)**\n' > "$PIPELINE_REPO/RISK-POLICY.md"
 }
 
 teardown() {
@@ -82,6 +83,25 @@ subagent_stop_input() {
     "$SESSION" "$TMP" "$TARGET" "$KEY"
 }
 
+pipeline_subagent_stop_input() {
+  printf '{"hook_event_name":"SubagentStop","session_id":"%s","cwd":"%s","agent_id":"%s","agent_type":"wr-risk-scorer:pipeline","last_assistant_message":"RISK_SCORES: commit=%s push=%s release=%s\\nRISK_CWD: %s"}' \
+    "${1:-child-session}" "$OTHER_REPO" "${2:-child-agent}" "${3:-4}" "${3:-4}" "${3:-4}" "$PIPELINE_REPO"
+}
+
+parent_bash_input() {
+  printf '{"hook_event_name":"PreToolUse","session_id":"%s","cwd":"%s","tool_name":"Bash","tool_input":{"cwd":"%s","command":"git commit --dry-run"}}' \
+    "$SESSION" "$PIPELINE_REPO" "$PIPELINE_REPO"
+}
+
+parent_prompt_input() {
+  printf '{"hook_event_name":"UserPromptSubmit","session_id":"%s","cwd":"%s","prompt":"continue"}' \
+    "$SESSION" "$PIPELINE_REPO"
+}
+
+dispatch_pretool() {
+  printf '%s' "$1" | "$HOOK_DIR/risk-scorer-dispatch.sh" pre-tool
+}
+
 @test "desktop SubagentStop marks completion before agent close" {
   dispatch "$(current_spawn_input)"
   dispatch_subagent_stop "$(subagent_stop_input)"
@@ -91,6 +111,96 @@ subagent_stop_input() {
 
   dispatch "$(current_close_input)"
   [ "$(find "$TMPDIR/claude-risk-$SESSION" -name 'codex-agent-*.done' | wc -l | tr -d ' ')" = "1" ]
+}
+
+@test "desktop pipeline SubagentStop hands a checkout-bound receipt to the parent without spawn state" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  [ ! -e "$TMPDIR/claude-risk-$SESSION/commit" ]
+
+  run dispatch_pretool "$(parent_bash_input)"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  rdir="$TMPDIR/claude-risk-$SESSION"
+  [ "$(cat "$rdir/commit")" = "4" ]
+  expected_hash="$(cd "$PIPELINE_REPO" && source "$HOOK_DIR/lib/gate-helpers.sh" && "$HOOK_DIR/lib/pipeline-state.sh" --hash-inputs | _hashcmd | cut -d' ' -f1)"
+  expected_checkout="$(cd "$PIPELINE_REPO" && source "$HOOK_DIR/lib/gate-helpers.sh" && _checkout_id)"
+  [ "$(cat "$rdir/state-hash")" = "$expected_hash" ]
+  [ "$(cat "$rdir/checkout-id")" = "$expected_checkout" ]
+  [ ! -e "$TMPDIR/claude-risk-child-session/commit" ]
+  [ "$(find "$PIPELINE_REPO/.risk-reports" -type f -name '*-commit.md' | wc -l | tr -d ' ')" = "1" ]
+  run grep -R "$PIPELINE_REPO" "$PIPELINE_REPO/.risk-reports"
+  [ "$status" -ne 0 ]
+
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  dispatch_pretool "$(parent_bash_input)"
+  [ "$(find "$PIPELINE_REPO/.risk-reports" -type f -name '*-commit.md' | wc -l | tr -d ' ')" = "1" ]
+}
+
+@test "a distinct completion from the same agent supersedes an unchanged checkout score" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input child-one agent-one 3)"
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input child-one agent-one 4)"
+  dispatch_pretool "$(parent_bash_input)"
+  [ "$(cat "$TMPDIR/claude-risk-$SESSION/commit")" = "4" ]
+  [ "$(find "$TMPDIR/claude-risk-pending" -type f ! -name '*.done' ! -name '*.claim' | wc -l | tr -d ' ')" = "0" ]
+}
+
+@test "duplicate delivery of the same completion writes one receipt" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  [ "$(find "$TMPDIR/claude-risk-pending" -type f ! -name '*.done' ! -name '*.claim' | wc -l | tr -d ' ')" = "1" ]
+}
+
+@test "Codex parent prompt imports a completed child receipt" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  run bash -c 'printf "%s" "$1" | "$2" user-prompt' _ "$(parent_prompt_input)" "$HOOK_DIR/risk-scorer-dispatch.sh"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TMPDIR/claude-risk-$SESSION/commit")" = "4" ]
+}
+
+@test "imported score retains the original assessment timestamp" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  pending="$(find "$TMPDIR/claude-risk-pending" -type f ! -name '*.done' ! -name '*.claim' -print -quit)"
+  assessed_seconds="$(node -e 'console.log(Math.floor(JSON.parse(require("fs").readFileSync(process.argv[1])).createdAt / 1000))' "$pending")"
+  sleep 1
+  printf '%s' "$(parent_bash_input)" | "$HOOK_DIR/risk-pending-receipt.sh"
+  born_seconds="$(source "$HOOK_DIR/lib/gate-helpers.sh" && _mtime "$TMPDIR/claude-risk-$SESSION/commit-born")"
+  [ "$born_seconds" = "$assessed_seconds" ]
+}
+
+@test "ordinary imported score does not renew an unrelated bypass marker" {
+  rdir="$TMPDIR/claude-risk-$SESSION"
+  mkdir -p "$rdir"
+  touch -t 200001010000 "$rdir/incident-release"
+  before="$(source "$HOOK_DIR/lib/gate-helpers.sh" && _mtime "$rdir/incident-release")"
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  printf '%s' "$(parent_bash_input)" | "$HOOK_DIR/risk-pending-receipt.sh"
+  after="$(source "$HOOK_DIR/lib/gate-helpers.sh" && _mtime "$rdir/incident-release")"
+  [ "$after" = "$before" ]
+}
+
+@test "pending pipeline receipt rejects checkout drift" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  printf 'drift\n' >> "$PIPELINE_REPO/state"
+  printf '%s' "$(parent_bash_input)" | "$HOOK_DIR/risk-pending-receipt.sh"
+  [ ! -e "$TMPDIR/claude-risk-$SESSION/commit" ]
+}
+
+@test "pending pipeline receipt rejects malformed completion" {
+  malformed="$(pipeline_subagent_stop_input | sed 's#RISK_CWD: [^\"]*#RISK_CWD: relative/path#')"
+  dispatch_subagent_stop "$malformed"
+  printf '%s' "$(parent_bash_input)" | "$HOOK_DIR/risk-pending-receipt.sh"
+  [ ! -e "$TMPDIR/claude-risk-$SESSION/commit" ]
+}
+
+@test "expired consumed receipt permits rescoring the unchanged checkout" {
+  dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  printf '%s' "$(parent_bash_input)" | "$HOOK_DIR/risk-pending-receipt.sh"
+  done_receipt="$(find "$TMPDIR/claude-risk-pending" -name '*.done' -print -quit)"
+  touch -t 200001010000 "$done_receipt"
+
+  RISK_TTL=1 dispatch_subagent_stop "$(pipeline_subagent_stop_input)"
+  [ "$(find "$TMPDIR/claude-risk-pending" -type f ! -name '*.done' ! -name '*.claim' | wc -l | tr -d ' ')" = "1" ]
 }
 
 @test "Codex completion bridge marks the exact risk agent when it closes" {


### PR DESCRIPTION
## Summary
- persist a sanitized, short-lived pipeline risk receipt when Codex observes completion only in the child conversation
- bind imports to the exact physical checkout, pipeline-state hash, and completion
- import through existing Bash or next-parent-prompt events without adding a hook

## Verification
- risk-scorer package suite: 449/449
- focused affected suites: 59/59
- architecture review: PASS