### PR TITLE
Handle Claude eval quota exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           fi
 
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-          if printf '%s\n' "$changed" | grep -Eq '^(packages/[^/]+/agents/|package(-lock)?\.json$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(\.github/workflows/ci\.yml|scripts/run-agent-evals-ci\.sh|packages/shared/test/agent-eval-quota-gate\.bats|packages/[^/]+/agents/.*|package(-lock)?\.json)$'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -202,4 +202,4 @@ jobs:
         if: steps.scope.outputs.run == 'true' && steps.token.outputs.present == 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: npm run eval:agents
+        run: scripts/run-agent-evals-ci.sh

--- a/docs/decisions/075-promptfoo-agent-prose-verdict-eval-harness.proposed.md
+++ b/docs/decisions/075-promptfoo-agent-prose-verdict-eval-harness.proposed.md
@@ -88,9 +88,15 @@ Per the 2026-07-04 interactive decision drain (ratified direction recorded on P2
 
 ### Amendment 2026-08-13 — path-scoped PR execution with full main validation
 
-The 2026-07-05 amendment's "every CI run" cadence spent finite Claude subscription quota and made unrelated PRs fail when that quota was exhausted, without adding evidence about the changed surface. For `pull_request` events, the `eval-agents` job now invokes Claude only when the diff touches an agent definition or eval (`packages/<plugin>/agents/**`) or a root promptfoo dependency (`package.json` / `package-lock.json`). The job remains present and reports a successful explicit skip for unrelated PRs. Every push to `main` still runs the full eval, and relevant token-bearing PRs still fail closed on provider or assertion errors. Fork-token handling and the deterministic Quality Gates are unchanged.
+The 2026-07-05 amendment's "every CI run" cadence spent finite Claude subscription quota and made unrelated PRs fail when that quota was exhausted, without adding evidence about the changed surface. For `pull_request` events, the `eval-agents` job now invokes Claude only when the diff touches an agent definition or eval (`packages/<plugin>/agents/**`), the eval workflow/wrapper/regression test, or a root promptfoo dependency (`package.json` / `package-lock.json`). The job remains present and reports a successful explicit skip for unrelated PRs. Every push to `main` still runs the full eval, and relevant token-bearing PRs still fail closed on provider or assertion errors. Fork-token handling and the deterministic Quality Gates are unchanged.
 
 This supersedes only the 2026-07-05 per-PR cadence. It does not treat quota exhaustion as passing evidence for a relevant change. The user approved this exact path-scoped workaround after the behavioural boundary was briefed on 2026-08-13; file-level oversight therefore remains `confirmed`.
+
+### Amendment 2026-08-13 — quota exhaustion is visible unavailable evidence, not a red build
+
+The path-scoped amendment still left every `main` push red while the Claude subscription reported its explicit weekly-limit error. That red state contained no behavioural result and could trigger unrelated red-CI recovery gates. Before promptfoo starts, a one-call availability probe treats only a single-line `You've hit your weekly limit` response as a successful job with a visible warning that no evidence was produced. Mixed output, authentication failure, transport error, an unrecognised provider failure, and any later promptfoo failure retain their non-zero status. When quota returns, the same command automatically resumes normal blocking validation without a configuration change.
+
+This is a degraded-availability workaround, not passing behavioural evidence. A quota-skipped run cannot be cited as Tier-A or Tier-B confirmation. The user requested disabling the Claude quality gate as a workaround; this narrower error classification preserves every failure mode that can still produce actionable evidence.
 
 ## Confirmation
 
@@ -100,7 +106,8 @@ This supersedes only the 2026-07-05 per-PR cadence. It does not treat quota exha
 4. **First slice (RFC-011 coverage):** the jtbd `[Unratified Dependency]` verdict eval fires the verdict when fed a change citing an unratified `developer` job (e.g. JTBD-001) and stays silent (PASS, no flag) on a ratified-job cite — covering already-shipped behaviour (no unratified-ADR dependency).
 5. **ADR-052 Surface-2 narrowing** + **ADR-005 reassessment flag** are recorded in those ADRs.
 6. ADR-075 carries `human-oversight: confirmed` (born-confirmed — substance + both sub-decisions user-confirmed via AskUserQuestion 2026-05-28).
-7. On pull requests, `.github/workflows/ci.yml` runs agent-prose evals only for agent or root promptfoo dependency changes; pushes to `main` always run them.
+7. On pull requests, `.github/workflows/ci.yml` runs agent-prose evals only for agent, eval-infrastructure, or root promptfoo dependency changes; pushes to `main` always run them.
+8. A quota-only availability probe emits a visible warning and exits successfully; quota mixed with another error and all eval failures remain blocking. `packages/shared/test/agent-eval-quota-gate.bats` covers quota-only, ordinary-failure, mixed-failure, and available-provider paths.
 
 ## Reassessment Criteria
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -314,7 +314,7 @@ _88 ADRs. These are the current rules. The architect agent reads this section fi
 ### ADR-075 — ADR-075: promptfoo as the behavioural test harness for agent-prose verdicts
 **Status:** proposed | **Oversight:** confirmed
 **Chosen:** Chosen: **adopt promptfoo as the agent-prose eval harness, alongside (not replacing) bats.**
-**Confirmation:** Agent or root promptfoo dependency changes run both eval tiers on pull requests; unrelated pull requests skip the Claude provider; every push to `main` runs the full eval.
+**Confirmation:** Agent, eval-infrastructure, or root promptfoo dependency changes run both eval tiers on pull requests; unrelated pull requests skip the Claude provider; every push to `main` runs the full eval. A quota-only availability probe is reported as unavailable evidence without making `main` red; mixed output and every eval failure remain blocking.
 **Related:** ADR-052, ADR-005, ADR-002, ADR-071, ADR-066
 
 ### ADR-076 — Inbound-reported problems rank ahead of internally-discovered problems via a sort tier

--- a/packages/shared/test/agent-eval-quota-gate.bats
+++ b/packages/shared/test/agent-eval-quota-gate.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMP=$(mktemp -d)
+  BIN="$TMP/bin"
+  mkdir -p "$BIN"
+  SCRIPT="$BATS_TEST_DIRNAME/../../../scripts/run-agent-evals-ci.sh"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+write_claude() {
+  cat > "$BIN/claude" <<EOF
+#!/bin/bash
+printf '%s\n' "$1"
+exit "$2"
+EOF
+  chmod +x "$BIN/claude"
+}
+
+write_npm() {
+  cat > "$BIN/npm" <<EOF
+#!/bin/bash
+touch "$TMP/npm-called"
+exit "$1"
+EOF
+  chmod +x "$BIN/npm"
+}
+
+@test "quota-only probe skips evals with a warning" {
+  write_claude "You've hit your weekly limit · resets Aug 15, 5am (UTC)" 1
+  write_npm 9
+
+  run env PATH="$BIN:$PATH" "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::Claude subscription quota is exhausted"* ]]
+  [ ! -e "$TMP/npm-called" ]
+}
+
+@test "ordinary probe failure remains blocking" {
+  write_claude "Authentication failed" 7
+  write_npm 0
+
+  run env PATH="$BIN:$PATH" "$SCRIPT"
+
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"Authentication failed"* ]]
+  [ ! -e "$TMP/npm-called" ]
+}
+
+@test "mixed quota and ordinary failure remains blocking" {
+  write_claude $'You\'ve hit your weekly limit\nAuthentication failed' 7
+  write_npm 0
+
+  run env PATH="$BIN:$PATH" "$SCRIPT"
+
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"Authentication failed"* ]]
+  [ ! -e "$TMP/npm-called" ]
+}
+
+@test "same-line quota and ordinary failure remains blocking" {
+  write_claude "You've hit your weekly limit · Authentication failed" 7
+  write_npm 0
+
+  run env PATH="$BIN:$PATH" "$SCRIPT"
+
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"Authentication failed"* ]]
+  [ ! -e "$TMP/npm-called" ]
+}
+
+@test "available probe delegates to evals and preserves their status" {
+  write_claude "available" 0
+  write_npm 9
+
+  run env PATH="$BIN:$PATH" "$SCRIPT"
+
+  [ "$status" -eq 9 ]
+  [ -e "$TMP/npm-called" ]
+}

--- a/scripts/run-agent-evals-ci.sh
+++ b/scripts/run-agent-evals-ci.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+set +e
+probe=$(claude -p "Reply exactly: available" 2>&1)
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  cleaned=$(printf '%s\n' "$probe" | tr -d '\r' | sed '/^[[:space:]]*$/d')
+  if [ "$(printf '%s\n' "$cleaned" | wc -l | tr -d ' ')" -eq 1 ] \
+    && printf '%s\n' "$cleaned" | grep -Eq "^You've hit your weekly limit( · resets [A-Za-z]{3} [0-9]{1,2}, [0-9]{1,2}(:[0-9]{2})?(am|pm) \(UTC\))?$"; then
+    echo "::warning::Claude subscription quota is exhausted; agent-prose evals produced no evidence and will retry on the next run."
+    exit 0
+  fi
+  printf '%s\n' "$probe" >&2
+  exit "$status"
+fi
+
+exec npm run eval:agents


### PR DESCRIPTION
## Summary

- classify only the exact Claude weekly-limit availability response as unavailable evidence
- keep mixed, provider, and behavioural-eval failures blocking
- add focused Bats coverage and align ADR-075

## Testing

- `bats packages/shared/test/agent-eval-quota-gate.bats`
- workflow YAML parse and staged diff check
