### PR TITLE
feat(itil): prefer upstream pull requests

### DIFF
--- a/.changeset/prefer-upstream-pull-request.md
+++ b/.changeset/prefer-upstream-pull-request.md
@@ -1,0 +1,17 @@
+---
+"@windyroad/itil": minor
+---
+
+`/wr-itil:report-upstream` now prefers opening a pull request over filing an issue, whenever the upstream accepts pull requests. Filing an issue remains the documented fallback.
+
+The predicate is whether the upstream accepts contributions, not whether you have write access to it. Fork-and-pull-request is the ordinary path, so the preference works for the third-party dependencies you do not own — which is most of them.
+
+It falls back to filing an issue when the upstream does not accept contributions, when the fix needs a design decision that is the maintainers' to make, when the ticket is security-classified (the private disclosure path is checked first and is unchanged), or when there is no defensible fix in hand. That last one is decided quietly: the skill never asks the person reporting a problem to produce a patch. The issue body is drafted first and the pull request is an upgrade of it, so a failed attempt still files the report rather than losing it.
+
+On the pull-request branch the body defers to the upstream's own `PULL_REQUEST_TEMPLATE.md` when there is one, and otherwise uses a short rationale-plus-cross-reference shape instead of the problem-report shape, which a diff already answers.
+
+Under AFK the pull-request branch degrades to the issue branch and queues the drafted pull request for your return. No unattended session pushes code into someone else's repository.
+
+Reports record a `pull request` disclosure path, and the skills that read it follow: `/wr-itil:check-upstream-responses` polls with `gh pr view`, and `/wr-itil:update-upstream` comments with `gh pr comment` and never closes a pull request — a merged one closes itself, and closing an unmerged one withdraws work you offered. Tickets filed before this change carry no disclosure path and are read as issues, exactly as before, with no extra API calls.
+
+The skill sends the pull request's title and body through the external-comms and voice-tone reviewers before creation; the command hook independently enforces the body review. Its diff is still unscored against the upstream's conventions, so the skill displays it before opening the pull request.

--- a/docs/decisions/028-voice-tone-gate-external-comms.proposed.md
+++ b/docs/decisions/028-voice-tone-gate-external-comms.proposed.md
@@ -1,8 +1,9 @@
 ---
 status: "proposed"
 date: 2026-04-20
-human-oversight: unconfirmed
+human-oversight: confirmed
 amended-date: 2026-08-04
+oversight-date: 2026-08-14
 decision-makers: [tomhoward]
 consulted: [wr-architect:agent, wr-jtbd:agent, wr-risk-scorer:wip]
 informed: [Windy Road plugin users, addressr maintainer, bbstats maintainer]
@@ -636,4 +637,4 @@ content-keyed PASS marker before close and that a later close is deduplicated.
 The isolated CLI smoke proves the completed-close fallback. Desktop evidence
 comes from a trusted hook writing a completion marker before agent close.
 
-**Oversight:** unconfirmed; correction surfaced to Tom Howard on 2026-08-04.
+**Oversight:** confirmed by Tom Howard on 2026-08-14.

--- a/docs/decisions/117-prefer-an-upstream-pull-request-over-an-issue.proposed.md
+++ b/docs/decisions/117-prefer-an-upstream-pull-request-over-an-issue.proposed.md
@@ -1,0 +1,135 @@
+---
+status: "proposed"
+date: 2026-08-08
+human-oversight: confirmed
+oversight-date: 2026-08-08
+decision-makers: [Tom Howard]
+consulted: [wr-architect:agent, wr-jtbd:agent]
+informed: [Windy Road plugin adopters]
+reassessment-date: 2026-11-08
+---
+
+# Prefer an upstream pull request over an issue when the upstream accepts pull requests
+
+## Context and Problem Statement
+
+`/wr-itil:report-upstream` can identify that a local problem belongs in another repository, but its only public reporting path is an issue. When a defensible fix is available, an issue leaves the work for the upstream maintainer while a pull request can deliver the fix directly.
+
+The maintainer ratified this decision's substance on 2026-08-08. It was originally recorded as ADR-102 on the unmerged implementation branch, but current `main` already assigns ADR-102 to the canonical story-map renderer. This collision-free record preserves the ratified substance without modifying either ADR-102 or the confirmed decisions it builds on.
+
+## Decision Drivers
+
+- A fix accepted upstream benefits every downstream adopter.
+- Most plugin adopters consume dependencies they do not own, so fork-and-pull-request must count.
+- Reporting a symptom must remain sufficient; the reporter is not required to author a patch.
+- Security disclosures must retain their private routing.
+- Unattended work must not push code into a third party's repository.
+- Pull-request prose must receive the same external-communications review as issue prose.
+
+## Considered Options
+
+1. **Prefer a pull request when the upstream accepts contributions (chosen)** - deliver a defensible fix directly, including through a fork.
+2. **Prefer a pull request only with upstream write access** - simpler, but excludes ordinary third-party contribution.
+3. **Keep the issue-only path** - lowest implementation cost, but preserves the one-way reporting queue.
+4. **Allow AFK sessions to open pull requests** - higher throughput, but lets an unattended agent publish code under the user's identity.
+
+## Decision Outcome
+
+Chosen option: **Prefer a pull request wherever the upstream accepts them.**
+
+When a local problem's fix belongs upstream, `/wr-itil:report-upstream` prefers a pull request if the upstream accepts contributions. The predicate is contribution acceptance, not write access; fork-and-pull-request is a normal successful path.
+
+The skill reuses discovery it already performs. An archived or disabled repository, or an explicit statement that outside contributions are not accepted, means the issue path. `CONTRIBUTING.md` or a pull-request template is positive evidence. When the signal is absent or ambiguous, the skill defaults to accepting contributions rather than adding a probe or refusing the ordinary fork-and-pull-request path.
+
+The skill files an issue instead when:
+
+1. The upstream does not accept contributions.
+2. The fix requires a design decision owned by the upstream maintainers.
+3. The ticket is security-classified and must use the existing private disclosure route.
+4. No defensible fix is available within three attempts or 20 minutes.
+
+The fourth classification is mechanical and silent. The skill drafts the issue body first, attempts the pull request as an upgrade, and falls back to the drafted issue if patch preparation fails.
+
+Deduplication searches both issues and pull requests and carries the matched artifact kind so an existing pull request receives `gh pr comment` rather than an issue command.
+
+The pull-request body follows the upstream's pull-request template when present. Otherwise it uses a short `What this changes`, `Why`, and `Cross-reference` shape rather than the issue-oriented problem-report template.
+
+Before `gh pr create`, the skill sends the combined title and body through the external-communications and voice-tone evaluators; the command hook independently enforces the body review. The skill also displays the full diff and names the upstream convention files it followed. The remaining absence of policy-aware scoring for a third-party diff is tracked by P497.
+
+Under AFK execution, the pull-request branch degrades to the issue branch and queues the drafted contribution for the interactive return. An unattended session never opens a pull request against a repository the user does not own.
+
+The `## Reported Upstream` section records disclosure path `pull request`. Consumers branch on that value:
+
+- response polling uses `gh pr view`;
+- lifecycle updates use `gh pr comment`;
+- local closure never runs `gh pr close`;
+- legacy tickets with no disclosure path remain issues without an extra probe.
+
+This decision adds behavior alongside ADR-024 and ADR-033. It does not amend their confirmed files.
+
+## Consequences
+
+### Good
+
+- A ready fix can reach all upstream adopters instead of waiting as an issue.
+- The path works for third-party dependencies through forks.
+- Failed pull-request attempts still produce an issue, so the original report is not lost.
+- Existing issue, security, polling, and lifecycle paths remain explicit fallbacks.
+
+### Neutral
+
+- A pull-request report spans two repositories and waits on upstream review.
+- Pull-request prose may be reviewed again after an issue-shaped draft because the gate key includes the surface.
+
+### Bad
+
+- Preparing and validating a contribution costs more time and quota than filing an issue.
+- No current scorer evaluates a diff against a third party's contribution policy; P497 remains open.
+- Operator-level hooks can interfere with work in the upstream checkout.
+
+## Pros and Cons of the Options
+
+### Prefer a pull request wherever the upstream accepts them (chosen)
+
+- Good, because it unblocks repositories we own and genuine third-party dependencies under one rule.
+- Good, because fork-and-PR needs no permission we have to negotiate for.
+- Good, because the prose gate already covers the new surface with no change.
+- Bad, because it commits the loop to a second repository's gates, conventions and release cadence.
+- Bad, because it opens a diff surface nothing currently scores.
+
+### Prefer a pull request only where we hold write access
+
+- Good, because it is the smaller change and needs no fork handling.
+- Bad, because it makes the feature a no-op for most adopters, who are consumers rather than owners.
+- Bad, because it repeats the failure mode ADR-024 already rejected in its Option 4.
+
+### Keep the issue-only path
+
+- Good, because it costs nothing to adopt and the machinery already works.
+- Bad, because it preserves a backlog of one-way reports whose ready fixes never land.
+
+### Prefer a pull request and let the AFK loop open it unattended
+
+- Good, because it maximises loop throughput and needs no interactive return.
+- Bad, because it lets a prose-only gate authorise code into a third party's repository under our name, which JTBD-006 rules out.
+
+## Confirmation
+
+- The report skill prefers a pull request based on contribution acceptance, not write access.
+- All four fallback conditions produce the issue or security path without asking the reporter to write a patch.
+- The pull-request path respects upstream templates and displays the outgoing diff.
+- AFK execution opens no third-party pull request.
+- Poll, catch-up, deduplication, comment, and local-closure behavior distinguish issues from pull requests.
+- Legacy tickets with no disclosure path make one issue API call and no probe.
+- Behavioral BATS and promptfoo cases cover acceptance, fallback, AFK, security, polling, and lifecycle behavior.
+
+## Reassessment Criteria
+
+Reassess if upstream maintainers consistently prefer issues to unsolicited pull requests, contribution preparation consumes more value than it delivers, or a rejected/reverted contribution demonstrates that P497 must become a precondition.
+
+## Related
+
+- [ADR-024](./024-cross-project-problem-reporting-contract.proposed.md) - existing cross-project reporting contract.
+- [ADR-033](./033-report-upstream-classifier-problem-first.proposed.md) - issue-body classifier retained on the issue branch.
+- [ADR-116](./116-ratified-decisions-change-only-by-supersession.proposed.md) - confirmed decision files remain unchanged.
+- [P497](../problems/open/497-upstream-pull-request-diff-is-unscored.md) - remaining diff-scoring gap.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,13 +11,13 @@ Compact rendered index of every ADR's chosen option, confirmation criteria, and 
 
 For deep-dive — creating, evolving, ratifying, or contesting a decision — open the per-ADR file directly. `/wr-architect:create-adr`, `/wr-architect:capture-adr`, and `/wr-architect:review-decisions` all keep the full body in scope. Decision Drivers, Considered Options bodies, Pros and Cons, Consequences narrative, and Reassessment Criteria are intentionally NOT in this routine view — they live in the per-ADR body.
 
-**Total ADRs:** 114 (103 in-force, 11 historical)
+**Total ADRs:** 115 (104 in-force, 11 historical)
 
 ---
 
 ## In-force decisions
 
-_103 ADRs. These are the current rules. The architect agent reads this section first for routine compliance review._
+_104 ADRs. These are the current rules. The architect agent reads this section first for routine compliance review._
 
 ### ADR-002 — Monorepo with Independently Installable Per-Plugin Packages
 **Status:** proposed | **Oversight:** confirmed
@@ -128,7 +128,7 @@ _103 ADRs. These are the current rules. The architect agent reads this section f
 **Related:** ADR-026, ADR-023, ADR-022, ADR-015, ADR-005
 
 ### ADR-028 — External-comms gate — voice-tone + risk/leak evaluators on shared PreToolUse surface
-**Status:** proposed | **Oversight:** unconfirmed
+**Status:** proposed | **Oversight:** confirmed
 **Related:** ADR-002, ADR-017, ADR-008, ADR-009, ADR-013, ADR-015, ADR-020, ADR-024, ADR-025, ADR-026, ADR-027
 
 ### ADR-029 — Diagnose before implement — structured hypothesis + evidence + RED-for-the-right-reason gate
@@ -345,8 +345,7 @@ _103 ADRs. These are the current rules. The architect agent reads this section f
 
 ### ADR-083 — Codex CLI as second runtime
 **Status:** proposed | **Oversight:** confirmed
-**Chosen:** **Option A — extend each existing package to both runtimes.** Claude remains the default; Codex support is added and validated one package at a time without duplicating the product tree.
-**Confirmation:** Each migrated package preserves its Claude-default installer, stages and installs its packed Codex artefact in isolation, passes manifest and generated-surface drift checks, and proves its actual skills or agents through isolated behavioural validation without adding speculative surfaces.
+**Chosen:** Chosen option: **"Option A — Extend each existing package to both runtimes"**,
 
 ### ADR-084 — Self-firing deferral census — a SessionStart surfacer so deferred governance work cannot silently rot
 **Status:** proposed | **Oversight:** confirmed
@@ -509,6 +508,12 @@ _103 ADRs. These are the current rules. The architect agent reads this section f
 ### ADR-116 — Ratified decisions change only by supersession
 **Status:** proposed | **Oversight:** confirmed
 **Confirmation:** The architect reviewer reports [Amendment To Ratified Decision] when a proposed change edits a confirmed decis...; The reviewer directs substantive change into a new superseding decision and does not accept clearing the overs...; A change that merely cites a legacy decision containing amendments does not trigger the finding.
+
+### ADR-117 — Prefer an upstream pull request over an issue when the upstream accepts pull requests
+**Status:** proposed | **Oversight:** confirmed
+**Chosen:** Chosen option: **Prefer a pull request wherever the upstream accepts them.**
+**Confirmation:** The report skill prefers a pull request based on contribution acceptance, not write access.; All four fallback conditions produce the issue or security path without asking the reporter to write a patch.; The pull-request path respects upstream templates and displays the outgoing diff.; AFK execution opens no third-party pull request.; Poll, catch-up, deduplication, comment, and local-closure behavior distinguish issues from pull requests.
+**Related:** ADR-024, ADR-033, ADR-116
 
 ---
 

--- a/docs/problems/README-history.md
+++ b/docs/problems/README-history.md
@@ -1318,3 +1318,7 @@ Last reviewed: 2026-04-28 **AFK iter 7 — P139 transitioned Open → Verificati
 > Last reviewed: 2026-08-08 **P485 captured** — every gate in the process adds something and is enforced; nothing removes, and removal is optional, so cruft accumulates until someone's patience runs out. Measured on the files this session touched: one is 64% comment-only, explaining states that no longer exist (lightweight aside via /wr-itil:capture-problem).
 
 > Last reviewed: 2026-08-09 **P486 captured** — a risk policy is the arbiter every commit, push and release is scored against, and the validator only checks its shape. An adopter's policy states in one sentence that a control can reduce impact and that controls never reduce impact; it passed validation (lightweight aside via /wr-itil:capture-problem).
+
+## 2026-08-14
+
+> Last reviewed: 2026-08-09 **P495 captured** — a full release-versioning run appeared in the working copy, consuming all five queued changesets and bumping two packages; it was uncommitted and recovered, but nothing warned and a consumed queue is indistinguishable from an empty one (lightweight aside via /wr-itil:capture-problem).

--- a/docs/problems/README.md
+++ b/docs/problems/README.md
@@ -1,6 +1,6 @@
 # Problem Backlog
 
-> Last reviewed: 2026-08-09 **P495 captured** — a full release-versioning run appeared in the working copy, consuming all five queued changesets and bumping two packages; it was uncommitted and recovered, but nothing warned and a consumed queue is indistinguishable from an empty one (lightweight aside via /wr-itil:capture-problem).
+> Last reviewed: 2026-08-14 **README reconciled** — one drift entry corrected: P497 added to WSJF Rankings. Reconciliation contract per P118 + ADR-014.
 
 > Run `/wr-itil:review-problems` to refresh WSJF rankings.
 
@@ -121,6 +121,7 @@ Dev-work queue only. Verification Pending (`.verifying.md`, WSJF multiplier 0) a
 | 2.25 | P136 | ADR-044 alignment audit — sweep all unaudited skills/hooks/agents/ADRs/JTBDs/READMEs against the framework-resolution boundary (master ticket) | 9 (Medium) | Open | L | 2026-04-27 | internal |
 | 2.25 | P290 | Harden ADR-052 to behavioural-only — remove the structural-test escape hatch entirely | 9 (Medium) | Open | L | 2026-05-25 | internal |
 | 2.25 | P324 | Agent-prose verdicts have no behavioural test harness — forcing the ADR-052 structural-test escape hatch + above-appetite release workarounds, perpetuating the structural tests the user has rejected | 9 (Medium) | Open | L | 2026-05-27 | internal |
+| 2.25 | P497 | An upstream pull-request diff is not scored against the upstream's conventions | 9 (Medium) | Open | L | 2026-08-14 | internal |
 | 2 | P170 | Problem tickets strain as fixes decompose into multiple coordinated changes — need an RFC framework that ties all changes back to problems (and unifies technical with user/business problems) | 8 (Medium) | Known Error | XL | 2026-05-04 | internal |
 | 1.875 | P091 | Session-wide context budget — Claude Code consumes substantial context before and during every session across all contributor surfaces (meta) | 15 (High) | Open | XL | 2026-04-22 | internal |
 | 1.125 | P298 | Plugin-published artifacts should NOT reference internal IDs at all (ADR-055 chose prefixing; strip them instead — they're meaningless to adopters) | 9 (Medium) | Open | XL | 2026-05-25 | internal |

--- a/docs/problems/open/497-upstream-pull-request-diff-is-unscored.md
+++ b/docs/problems/open/497-upstream-pull-request-diff-is-unscored.md
@@ -1,0 +1,52 @@
+# Problem 497: An upstream pull-request diff is not scored against the upstream's conventions
+
+**Status**: Open
+**Reported**: 2026-08-14
+**Priority**: 9 (Medium) - Impact: 3 x Likelihood: 3
+**Origin**: internal
+**Effort**: L
+**WSJF**: 2.25 - (9 x 1.0) / 4
+**JTBD**: JTBD-001, JTBD-010
+**Persona**: developer
+
+## Description
+
+ADR-117 makes a pull request the preferred upstream report when a defensible fix is available. The skill explicitly sends its title and body through the external-communications evaluators, while the command hook enforces the body review. No scorer evaluates the diff against the upstream repository's contribution policy, conventions, or risk appetite.
+
+## Symptoms
+
+- A contribution can be opened after prose review without policy-aware diff review.
+- The local pipeline scorer applies this repository's policy, not the upstream's.
+- There is no assessment action for a contribution to a repository the user does not own.
+
+## Workaround
+
+In interactive sessions, display and review the full diff and the upstream's `CONTRIBUTING.md`, pull-request template, lint configuration, and CI workflow before `gh pr create`. ADR-117 forbids AFK sessions from opening the pull request.
+
+## Impact Assessment
+
+- **Who is affected**: upstream maintainers, the contributor's reputation, and downstream adopters of the proposed change.
+- **Frequency**: every interactive pull request opened through ADR-117.
+- **Severity**: Medium - the likely harm is a rejected or regretted contribution rather than a local package regression.
+
+## Root Cause Analysis
+
+The risk model assumes that diffs land in the current repository and can be judged against its local `RISK-POLICY.md`. A contribution crosses that boundary without an equivalent machine-readable upstream policy.
+
+### Investigation Tasks
+
+- [ ] Decide whether contribution review needs a new scorer action or a mode on the existing pipeline scorer.
+- [ ] Determine which upstream convention files are reliable inputs.
+- [ ] Define appetite for a repository the user does not own.
+- [ ] Use evidence from the first real ADR-117 contribution before selecting the mechanism.
+
+## Dependencies
+
+- **Blocks**: none; ADR-117 requires human diff review and forbids AFK publication.
+- **Blocked by**: evidence from a real upstream contribution.
+- **Composes with**: ADR-015, ADR-028, ADR-117, and `RISK-POLICY.md`.
+
+## Related
+
+- [ADR-117](../../decisions/117-prefer-an-upstream-pull-request-over-an-issue.proposed.md)
+- GitHub issue [#416](https://github.com/windyroad/agent-plugins/issues/416) tracks the original observation.

--- a/packages/itil/scripts/catchup-scan.sh
+++ b/packages/itil/scripts/catchup-scan.sh
@@ -45,7 +45,7 @@
 # Structured stdout (one per actionable upstream entry; <= 150 bytes per
 # line per ADR-038). ASCII `->` for the transition arrow per the P334
 # awk/script portability lesson (no Unicode in machine-read output):
-#   CATCHUP P<NNN> <url> state=<state> transition=<KE->Verifying|Verifying->Closed>
+#   CATCHUP P<NNN> <url> state=<state> transition=<KE->Verifying|Verifying->Closed> disclosure=<issue|pull-request>
 #   CATCHUP P<NNN> inbound-<ref> state=<state> transition=<…> direction=inbound
 #   SKIP    P<NNN> <url> reason=already-logged
 #   SKIP    P<NNN> inbound-<ref> reason=already-logged
@@ -64,6 +64,10 @@
 # @adr ADR-049 (invoked via wr-itil-catchup-scan bin shim, never repo-relative path)
 # @adr ADR-032 (foreground synchronous skill)
 # @adr ADR-076 (reads the `**Origin**: inbound-reported (#NN)` field for the inbound leg)
+# @adr ADR-117 (prefer an upstream pull request over an issue — the CATCHUP
+#   row carries a `disclosure=` discriminator so the consuming skill knows
+#   whether to comment on a pull request or an issue. A `pull request` path
+#   is actionable, so it is NOT skipped alongside out-of-band / mailbox.)
 # @problem P376 — catchup scanner misses the inbound direction (cross-direction parity)
 # @rfc RFC-028 (consume the Origin field for inbound-reported verdict — extended to the catchup surface)
 # @jtbd JTBD-301 (reporter feedback loop — the catchup's primary job)
@@ -264,8 +268,17 @@ for ticket_file in "${TICKET_FILES[@]}"; do
       printf "SKIP    %s %s reason=already-logged\n" "$ticket_id" "$upstream_url"
       SKIP_LOGGED=$((SKIP_LOGGED + 1))
     else
-      printf "CATCHUP %s %s state=%s transition=%s\n" \
-        "$ticket_id" "$upstream_url" "$state" "$transition"
+      # Carry the artefact kind to the consumer. Without it the value is
+      # recorded on the ticket and never acted on, and `/wr-itil:update-upstream`
+      # runs `gh issue comment` against a pull request. Hyphenated on the wire
+      # so the row stays whitespace-tokenisable; the ticket body keeps the
+      # spaced `pull request` spelling.
+      case "$disclosure" in
+        *pull*request*) disclosure_field="pull-request" ;;
+        *) disclosure_field="issue" ;;
+      esac
+      printf "CATCHUP %s %s state=%s transition=%s disclosure=%s\n" \
+        "$ticket_id" "$upstream_url" "$state" "$transition" "$disclosure_field"
       CATCHUP_COUNT=$((CATCHUP_COUNT + 1))
     fi
   fi

--- a/packages/itil/scripts/check-upstream-responses.sh
+++ b/packages/itil/scripts/check-upstream-responses.sh
@@ -5,10 +5,11 @@
 # discovery pipeline. Scans local problem tickets for `## Reported
 # Upstream` back-link sections (written by `/wr-itil:report-upstream`
 # Step 7), polls each upstream issue via `gh issue view`, diffs against
-# cache, and surfaces new comments / state changes / label changes since
+# cache, and surfaces new responses / state changes / label changes since
 # last check.
 #
-# Read-only externally: only `gh issue view` (read-only) — no
+# Read-only externally: `gh issue view`, or `gh pr view` plus the pull
+# request's inline review comments via `gh api` — no
 # `gh issue comment` / `gh issue create`. Does NOT trip ADR-028
 # external-comms gate. AFK-safe.
 #
@@ -28,13 +29,13 @@
 #       written to cache + audit-log
 #
 # Structured stdout (one per ticket; ≤ 150 bytes per line per ADR-038):
-#   NEW     P<NNN> <url> state=<state> new-comments=<N>
+#   NEW     P<NNN> <url> state=<state> new-responses=<N>
 #   STATE   P<NNN> <url> state=<old>→<new>
 #   LABEL   P<NNN> <url> labels-added=<csv> labels-removed=<csv>
 #   NONE    P<NNN> <url> no-change-since=<last-checked>
 #   FAIL    P<NNN> <url> reason=<gh-error-short>
 #
-# Precedence when multiple change classes apply: STATE > NEW (comments) > LABEL > NONE.
+# Precedence when multiple change classes apply: STATE > NEW (responses) > LABEL > NONE.
 #
 # @problem P249 — no process for issue reporters to check for responses (Phase 1)
 # @adr ADR-014 (governance skills commit their own work)
@@ -44,6 +45,14 @@
 # @adr ADR-038 (progressive disclosure — per-row byte budget)
 # @adr ADR-049 (invoked via wr-itil-check-upstream-responses bin shim)
 # @adr ADR-062 (inbound discovery — symmetric counterpart)
+# @adr ADR-117 (prefer an upstream pull request over an issue — the
+#   `## Reported Upstream` disclosure path selects `gh pr view` over
+#   `gh issue view`. An ABSENT path means a ticket written before that
+#   decision, which the pre-ADR-117 skill could only ever have filed as
+#   a public issue — so absent means issue, and no probe is needed. This
+#   is the explicit legacy-path decision ADR-117 requires; an
+#   issue-then-pr probe would double the call count for every legacy
+#   ticket on every cycle against a `gh` rate budget nothing governs.)
 # @jtbd JTBD-004 (cross-repo coordination — primary anchor)
 # @jtbd JTBD-006 (AFK-safe)
 # @jtbd JTBD-001 (governance without slowing down)
@@ -146,6 +155,30 @@ extract_upstream_url() {
   ' "$1"
 }
 
+# Extract the `## Reported Upstream` disclosure-path line (lower-cased).
+# Same awk shape as catchup-scan.sh's helper of the same name.
+extract_disclosure_path() {
+  awk '
+    /^## Reported Upstream/ { in_section = 1; next }
+    /^## / && in_section { in_section = 0 }
+    in_section && /^- \*\*Disclosure path\*\*:/ {
+      sub(/^- \*\*Disclosure path\*\*: */, "")
+      print
+      exit
+    }
+  ' "$1" | tr "[:upper:]" "[:lower:]"
+}
+
+# Which `gh` read subcommand polls this ticket's upstream artefact?
+# `pull request` (or `pull-request`) → `gh pr view`; anything else,
+# INCLUDING an absent disclosure path, → `gh issue view` (ADR-117).
+upstream_view_noun() {
+  case "$1" in
+    *pull*request*) echo "pr" ;;
+    *) echo "issue" ;;
+  esac
+}
+
 # Extract numeric ID prefix from a ticket file basename.
 extract_ticket_id() {
   local base
@@ -189,8 +222,16 @@ for ticket_file in "${TICKET_FILES[@]}"; do
 
   POLL_COUNT=$((POLL_COUNT + 1))
 
-  # Poll the upstream.
-  if ! gh_output="$("$GH_BIN" issue view "$upstream_url" --json comments,state,labels,updatedAt 2>&1)"; then
+  # Poll the upstream. Pull requests need one additional read because
+  # `gh pr view` omits inline review-thread comments. `state` carries MERGED
+  # for a merged pull request, distinct from CLOSED.
+  view_noun="$(upstream_view_noun "$(extract_disclosure_path "$ticket_file")")"
+  if [ "$view_noun" = "pr" ]; then
+    view_fields="comments,reviews,state,labels,updatedAt"
+  else
+    view_fields="comments,state,labels,updatedAt"
+  fi
+  if ! gh_output="$("$GH_BIN" "$view_noun" view "$upstream_url" --json "$view_fields" 2>&1)"; then
     short_reason="$(echo "$gh_output" | head -1 | cut -c1-80)"
     printf "FAIL    %s %s reason=%s\n" "$ticket_id" "$upstream_url" "$short_reason"
     PARTIAL_FAILURE=1
@@ -198,39 +239,67 @@ for ticket_file in "${TICKET_FILES[@]}"; do
     continue
   fi
 
+  if [ "$view_noun" = "pr" ]; then
+    pr_path="${upstream_url#https://github.com/}"
+    pr_path="${pr_path%/}"
+    review_endpoint="repos/${pr_path/\/pull\//\/pulls\/}/comments"
+    if ! review_pages="$("$GH_BIN" api "$review_endpoint" --paginate --slurp 2>&1)"; then
+      short_reason="$(echo "$review_pages" | head -1 | cut -c1-80)"
+      printf "FAIL    %s %s reason=%s\n" "$ticket_id" "$upstream_url" "$short_reason"
+      PARTIAL_FAILURE=1
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      continue
+    fi
+    if ! review_comments="$(echo "$review_pages" | jq -c 'add // []' 2>/dev/null)"; then
+      printf "FAIL    %s %s reason=malformed-inline-review-response\n" "$ticket_id" "$upstream_url"
+      PARTIAL_FAILURE=1
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      continue
+    fi
+    gh_output="$(jq -cn --argjson base "$gh_output" --argjson inline "$review_comments" '$base + {reviewComments: $inline}')"
+  else
+    gh_output="$(jq -cn --argjson base "$gh_output" '$base + {reviewComments: []}')"
+  fi
+
   # Parse upstream state.
   current_state="$(echo "$gh_output" | jq -r '.state // "UNKNOWN"')"
-  current_comment_count="$(echo "$gh_output" | jq -r '.comments | length')"
+  current_response_count="$(echo "$gh_output" | jq -r '((.comments // []) | length) + ((.reviews // []) | length) + ((.reviewComments // []) | length)')"
   current_labels_csv="$(echo "$gh_output" | jq -r '[.labels[].name] | sort | join(",")')"
   current_updated_at="$(echo "$gh_output" | jq -r '.updatedAt // ""')"
+  current_response_updated_at="$(echo "$gh_output" | jq -r '[
+    (.comments[]? | .updatedAt // .createdAt),
+    (.reviews[]? | .updatedAt // .submittedAt // .createdAt),
+    (.reviewComments[]? | .updatedAt // .createdAt)
+  ] | map(select(. != null and . != "")) | max // ""')"
 
   # Look up cache entry.
   cache_state="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_seen_state // \"\"")"
-  cache_comment_count="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_seen_comment_count // -1")"
+  cache_response_count="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_seen_response_count // .tickets[\"$ticket_id\"].last_seen_comment_count // -1")"
   cache_labels_csv="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_seen_labels // [] | sort | join(\",\")")"
   cache_last_checked="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_checked_at // \"\"")"
+  cache_response_updated_at="$(echo "$UPDATED_CACHE" | jq -r ".tickets[\"$ticket_id\"].last_seen_response_updated_at // \"\"")"
 
-  # Decide the change class (precedence: STATE > NEW (comments) > LABEL > NONE).
+  # Decide the change class (precedence: STATE > NEW (responses/activity) > LABEL > NONE).
   no_cache_entry=0
-  if [ -z "$cache_state" ] || [ "$cache_comment_count" = "-1" ]; then
+  if [ -z "$cache_state" ] || [ "$cache_response_count" = "-1" ]; then
     no_cache_entry=1
   fi
 
   if [ "$FORCE_RECHECK" -eq 1 ] || [ "$no_cache_entry" -eq 1 ]; then
-    delta="$current_comment_count"
+    delta="$current_response_count"
     if [ "$no_cache_entry" -eq 0 ]; then
-      delta=$((current_comment_count - cache_comment_count))
+      delta=$((current_response_count - cache_response_count))
       [ "$delta" -lt 0 ] && delta=0
     fi
-    printf "NEW     %s %s state=%s new-comments=%s\n" "$ticket_id" "$upstream_url" "$current_state" "$delta"
+    printf "NEW     %s %s state=%s new-responses=%s\n" "$ticket_id" "$upstream_url" "$current_state" "$delta"
     NEW_COUNT=$((NEW_COUNT + 1))
   elif [ "$current_state" != "$cache_state" ]; then
     printf "STATE   %s %s state=%s→%s\n" "$ticket_id" "$upstream_url" "$cache_state" "$current_state"
     STATE_CHANGE_COUNT=$((STATE_CHANGE_COUNT + 1))
-  elif [ "$current_comment_count" -ne "$cache_comment_count" ]; then
-    delta=$((current_comment_count - cache_comment_count))
+  elif [ "$current_response_count" -ne "$cache_response_count" ] || { [ -n "$cache_response_updated_at" ] && [ "$current_response_updated_at" != "$cache_response_updated_at" ]; }; then
+    delta=$((current_response_count - cache_response_count))
     [ "$delta" -lt 0 ] && delta=0
-    printf "NEW     %s %s state=%s new-comments=%s\n" "$ticket_id" "$upstream_url" "$current_state" "$delta"
+    printf "NEW     %s %s state=%s new-responses=%s\n" "$ticket_id" "$upstream_url" "$current_state" "$delta"
     NEW_COUNT=$((NEW_COUNT + 1))
   elif [ "$current_labels_csv" != "$cache_labels_csv" ]; then
     # Compute labels added/removed.
@@ -251,15 +320,17 @@ for ticket_file in "${TICKET_FILES[@]}"; do
     --arg state "$current_state" \
     --arg checked "$now_iso" \
     --arg updated "$current_updated_at" \
-    --argjson count "$current_comment_count" \
+    --arg response_updated "$current_response_updated_at" \
+    --argjson count "$current_response_count" \
     --argjson labels "$(echo "$gh_output" | jq '[.labels[].name] | sort')" \
     '.tickets[$id] = {
       upstream_url: $url,
       last_checked_at: $checked,
       last_seen_state: $state,
-      last_seen_comment_count: $count,
+      last_seen_response_count: $count,
       last_seen_labels: $labels,
-      last_seen_updated_at: $updated
+      last_seen_updated_at: $updated,
+      last_seen_response_updated_at: $response_updated
     }')"
 done
 

--- a/packages/itil/scripts/test/catchup-scan.bats
+++ b/packages/itil/scripts/test/catchup-scan.bats
@@ -272,3 +272,73 @@ make_inbound_ticket() {
   [[ "$output" != *"P400"* ]]
   [[ "$output" != *"P401"* ]]
 }
+
+# ── ADR-117: the CATCHUP row carries the artefact discriminator ─────────────
+#
+# ADR-117 adds a `pull request` disclosure path. Two things must hold: the
+# path is ACTIONABLE (so it must not be skipped alongside out-of-band and
+# mailbox), and the discriminator must reach the consumer on the worklist
+# row — otherwise `/wr-itil:update-upstream` runs `gh issue comment` against
+# a pull request. Recording the value on the ticket without propagating it
+# is the half-migration these cases exist to catch.
+#
+# @jtbd JTBD-201 (audit trail — issue vs pull request stays distinguishable)
+# @jtbd JTBD-001 (governance without slowing down — the worklist is derived,
+#   not hand-policed, so the row has to carry what the consumer needs)
+# @adr ADR-117
+
+@test "ADR-117: a pull-request ticket emits CATCHUP with disclosure=pull-request" {
+  make_reported_ticket "500-pr.closed.md" "https://github.com/o/r/pull/5" "pull request"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CATCHUP P500 https://github.com/o/r/pull/5 state=closed transition=Verifying->Closed disclosure=pull-request"* ]]
+}
+
+@test "ADR-117: a pull-request ticket is NOT skipped as out-of-band" {
+  make_reported_ticket "501-pr.closed.md" "https://github.com/o/r/pull/6" "pull request"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SKIP    P501"* ]]
+  [[ "$output" == *"CATCHUP P501"* ]]
+}
+
+@test "ADR-117: an issue ticket emits CATCHUP with disclosure=issue" {
+  make_reported_ticket "502-issue.closed.md" "https://github.com/o/r/issues/7" "public issue"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CATCHUP P502 https://github.com/o/r/issues/7 state=closed transition=Verifying->Closed disclosure=issue"* ]]
+}
+
+@test "ADR-117: a legacy ticket with no disclosure-path line emits disclosure=issue" {
+  # Pre-ADR-117 tickets carry no disclosure path; absent means issue.
+  make_reported_ticket "503-legacy.closed.md" "https://github.com/o/r/issues/8" ""
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CATCHUP P503 https://github.com/o/r/issues/8"* ]]
+  [[ "$output" == *"disclosure=issue"* ]]
+}
+
+@test "ADR-117: the hyphenated pull-request spelling is tolerated on the wire" {
+  make_reported_ticket "504-pr.closed.md" "https://github.com/o/r/pull/9" "pull-request"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"disclosure=pull-request"* ]]
+}
+
+@test "ADR-117: out-of-band and mailbox paths are still skipped" {
+  make_reported_ticket "505-oob.closed.md" "https://github.com/o/r/issues/10" "drafted-and-saved (out-of-band)"
+  make_reported_ticket "506-mbx.closed.md" "https://github.com/o/r/issues/11" "mailbox"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP    P505"* ]]
+  [[ "$output" == *"SKIP    P506"* ]]
+}
+
+@test "ADR-117: the outbound worklist row stays within the ADR-038 150-byte budget" {
+  make_reported_ticket "507-long.closed.md" "https://github.com/averylongowner/withaverylongreponame/pull/123456" "pull request"
+  run bash "$SCRIPT" --problems-dir "$FIX"
+  [ "$status" -eq 0 ]
+  line="$(printf '%s\n' "$output" | grep '^CATCHUP P507')"
+  [ -n "$line" ]
+  [ "${#line}" -le 150 ]
+}

--- a/packages/itil/scripts/test/check-upstream-responses.bats
+++ b/packages/itil/scripts/test/check-upstream-responses.bats
@@ -13,7 +13,8 @@
 # script that polls upstream issues, writes cache + audit-log, and
 # emits a structured one-line-per-ticket report to stdout.
 #
-# Read-soft externally: only `gh issue view` (read-only) — no
+# Read-soft externally: `gh issue view`, or `gh pr view` plus `gh api` for
+# inline review comments (all read-only) — no
 # `gh issue comment` / `gh issue create`. Does NOT trip ADR-028
 # external-comms gate. AFK-safe.
 #
@@ -35,7 +36,7 @@
 #
 # Structured stdout format (≤ 150 bytes per line per ADR-038
 # progressive-disclosure budget):
-#   NEW     P<NNN> <url> state=<state> new-comments=<N>
+#   NEW     P<NNN> <url> state=<state> new-responses=<N>
 #   STATE   P<NNN> <url> state=<old>→<new>
 #   LABEL   P<NNN> <url> labels-added=<csv> labels-removed=<csv>
 #   NONE    P<NNN> <url> no-change-since=<last-checked>
@@ -255,7 +256,7 @@ EOF
   run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
   [ "$status" -eq 0 ]
   echo "$output" | grep -qE "^NEW *P103"
-  echo "$output" | grep -q "new-comments=2"
+  echo "$output" | grep -q "new-responses=2"
 }
 
 # ── Behavioural: state change surfaces STATE marker ─────────────────────────
@@ -500,4 +501,226 @@ EOF
   [ "$status" -eq 0 ]
   # With --force-recheck, the line is emitted as NEW regardless of cache match.
   echo "$output" | grep -qE "^NEW *P112"
+}
+
+# ── Behavioural: disclosure path selects the gh read subcommand (ADR-117) ───
+#
+# ADR-117 makes a pull request the preferred outbound artefact. `gh issue view`
+# errors on a pull-request URL, so a ticket whose `## Reported Upstream`
+# disclosure path records `pull request` must be polled with `gh pr view`.
+# These cases exercise the real script against a fake `gh` that accepts ONLY
+# the correct noun for the artefact it was primed with — so polling with the
+# wrong subcommand surfaces as FAIL rather than as a silent pass.
+#
+# @jtbd JTBD-201 (audit trail — a rejected pull request must not be recorded
+#   as a resolution, which needs the poll to reach the pull request at all)
+# @jtbd JTBD-010 (per-report token burn — legacy issues remain one call; pull
+#   requests use one additional bounded read for inline review comments)
+# @adr ADR-117
+
+# Fake `gh` that answers only the given noun, and records the noun it saw.
+make_noun_strict_gh() {
+  local accept="$1"
+  cat > "$GHFAKE_DIR/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$1 \$2" >> "\$GHFAKE_DATA/nouns.log"
+if [ "\$1" = "api" ]; then
+  if [ -f "\$GHFAKE_DATA/review-comments.json" ]; then
+    cat "\$GHFAKE_DATA/review-comments.json"
+  else
+    printf '[[]]'
+  fi
+  exit 0
+fi
+if [ "\$1" = "$accept" ] && [ "\$2" = "view" ]; then
+  URL="\$3"
+  HASH=\$(echo -n "\$URL" | shasum | awk '{print \$1}')
+  if [ -f "\$GHFAKE_DATA/\$HASH.json" ]; then cat "\$GHFAKE_DATA/\$HASH.json"; exit 0; fi
+  echo "no canned response for \$URL" >&2; exit 1
+fi
+echo "gh: '\$1 \$2' is not valid for this artefact" >&2
+exit 1
+EOF
+  chmod +x "$GHFAKE_DIR/gh"
+}
+
+write_upstream_ticket() {
+  local file="$1" url="$2" disclosure="$3"
+  {
+    echo "# Problem: fixture"
+    echo ""
+    echo "**Status**: Open"
+    echo ""
+    echo "## Reported Upstream"
+    echo ""
+    echo "- **URL**: $url"
+    echo "- **Reported**: 2026-08-08"
+    [ -n "$disclosure" ] && echo "- **Disclosure path**: $disclosure"
+    echo "- **Cross-reference confirmed**: yes"
+  } > "$PROBLEMS_DIR/$file"
+}
+
+@test "ADR-117: a pull-request disclosure path is polled with gh pr view, not gh issue view" {
+  write_upstream_ticket "300-pr.open.md" "https://github.com/example/repo/pull/7" "pull request"
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/7" '{"state":"OPEN","comments":[{"id":1,"author":{"login":"m"},"createdAt":"2026-08-08T00:00:00Z","body":"review"}],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE "^NEW *P300"
+  ! echo "$output" | grep -qE "^FAIL *P300"
+  grep -q '^pr view$' "$GHFAKE_DIR/nouns.log"
+  ! grep -q '^issue view$' "$GHFAKE_DIR/nouns.log"
+}
+
+@test "ADR-117: a new pull-request review is surfaced as a response" {
+  write_upstream_ticket "305-review.open.md" "https://github.com/example/repo/pull/12" "pull request"
+  cat > "$CACHE_FILE" <<'EOF'
+{
+  "last_checked": "2026-08-08T00:00:00Z",
+  "tickets": {
+    "P305": {
+      "upstream_url": "https://github.com/example/repo/pull/12",
+      "last_checked_at": "2026-08-08T00:00:00Z",
+      "last_seen_state": "OPEN",
+      "last_seen_response_count": 0,
+      "last_seen_labels": [],
+      "last_seen_updated_at": "2026-08-08T00:00:00Z"
+    }
+  }
+}
+EOF
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/12" '{"state":"OPEN","comments":[],"reviews":[{"id":"r1","state":"CHANGES_REQUESTED","body":"Please adjust this."}],"labels":[],"updatedAt":"2026-08-09T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE '^NEW *P305'
+  echo "$output" | grep -q 'new-responses=1'
+  [ "$(jq -r '.tickets.P305.last_seen_response_count' "$CACHE_FILE")" -eq 1 ]
+}
+
+@test "ADR-117: a new inline pull-request review comment is surfaced as a response" {
+  write_upstream_ticket "307-inline-review.open.md" "https://github.com/example/repo/pull/14" "pull request"
+  cat > "$CACHE_FILE" <<'EOF'
+{
+  "last_checked": "2026-08-08T00:00:00Z",
+  "tickets": {
+    "P307": {
+      "upstream_url": "https://github.com/example/repo/pull/14",
+      "last_checked_at": "2026-08-08T00:00:00Z",
+      "last_seen_state": "OPEN",
+      "last_seen_response_count": 0,
+      "last_seen_labels": [],
+      "last_seen_response_updated_at": "2026-08-08T00:00:00Z"
+    }
+  }
+}
+EOF
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/14" '{"state":"OPEN","comments":[],"reviews":[],"labels":[],"updatedAt":"2026-08-09T00:00:00Z"}'
+  printf '%s' '[[{"id":91,"createdAt":"2026-08-09T01:00:00Z","body":"Please rename this."}]]' > "$GHFAKE_DIR/review-comments.json"
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE '^NEW *P307'
+  echo "$output" | grep -q 'new-responses=1'
+  [ "$(jq -r '.tickets.P307.last_seen_response_count' "$CACHE_FILE")" -eq 1 ]
+  [ "$(jq -r '.tickets.P307.last_seen_response_updated_at' "$CACHE_FILE")" = "2026-08-09T01:00:00Z" ]
+}
+
+@test "ADR-117: pull-request metadata updates do not mask a label-only change as a response" {
+  write_upstream_ticket "308-label.open.md" "https://github.com/example/repo/pull/15" "pull request"
+  cat > "$CACHE_FILE" <<'EOF'
+{
+  "last_checked": "2026-08-08T00:00:00Z",
+  "tickets": {
+    "P308": {
+      "upstream_url": "https://github.com/example/repo/pull/15",
+      "last_checked_at": "2026-08-08T00:00:00Z",
+      "last_seen_state": "OPEN",
+      "last_seen_response_count": 0,
+      "last_seen_labels": [],
+      "last_seen_updated_at": "2026-08-08T00:00:00Z",
+      "last_seen_response_updated_at": ""
+    }
+  }
+}
+EOF
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/15" '{"state":"OPEN","comments":[],"reviews":[],"labels":[{"name":"needs-review"}],"updatedAt":"2026-08-09T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE '^LABEL *P308'
+  ! echo "$output" | grep -qE '^NEW *P308'
+}
+
+@test "ADR-117: the hyphenated pull-request spelling is tolerated" {
+  write_upstream_ticket "301-pr.open.md" "https://github.com/example/repo/pull/8" "pull-request"
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/8" '{"state":"MERGED","comments":[],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qE "^FAIL *P301"
+  grep -q '^pr view$' "$GHFAKE_DIR/nouns.log"
+}
+
+@test "ADR-117: a dedup comment on an existing pull request is polled as a pull request" {
+  write_upstream_ticket "306-pr-comment.open.md" "https://github.com/example/repo/pull/13" "commented-on-existing-pull-request"
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/13" '{"state":"OPEN","comments":[],"reviews":[],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qE '^FAIL *P306'
+  grep -q '^pr view$' "$GHFAKE_DIR/nouns.log"
+}
+
+@test "ADR-117: a merged pull request reports MERGED, distinct from CLOSED" {
+  write_upstream_ticket "302-merged.open.md" "https://github.com/example/repo/pull/9" "pull request"
+  make_noun_strict_gh "pr"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/pull/9" '{"state":"MERGED","comments":[],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "MERGED"
+  ! echo "$output" | grep -q "CLOSED"
+}
+
+@test "ADR-117: an issue disclosure path still polls with gh issue view" {
+  write_upstream_ticket "303-issue.open.md" "https://github.com/example/repo/issues/10" "public issue"
+  make_noun_strict_gh "issue"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/issues/10" '{"state":"OPEN","comments":[],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qE "^FAIL *P303"
+  grep -q '^issue view$' "$GHFAKE_DIR/nouns.log"
+}
+
+@test "ADR-117: a legacy ticket with NO disclosure path polls as an issue, with no probe" {
+  # Tickets written before ADR-117 carry no disclosure-path line at all. The
+  # pre-ADR-117 skill could only ever have filed a public issue, so absent
+  # means issue. Exactly one call — an issue-then-pr probe ladder would show
+  # up here as a second entry in nouns.log.
+  write_upstream_ticket "304-legacy.open.md" "https://github.com/example/repo/issues/11" ""
+  make_noun_strict_gh "issue"
+  export GHFAKE_DATA="$GHFAKE_DIR"
+  prime_gh_response "https://github.com/example/repo/issues/11" '{"state":"OPEN","comments":[],"labels":[],"updatedAt":"2026-08-08T00:00:00Z"}'
+
+  run "$SCRIPT" --problems-dir "$PROBLEMS_DIR" --cache-file "$CACHE_FILE" --audit-log "$AUDIT_LOG" --gh-bin "$GHFAKE_DIR/gh"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -qE "^FAIL *P304"
+  [ "$(wc -l < "$GHFAKE_DIR/nouns.log" | tr -d ' ')" -eq 1 ]
+  grep -q '^issue view$' "$GHFAKE_DIR/nouns.log"
 }

--- a/packages/itil/skills/check-upstream-responses/SKILL.md
+++ b/packages/itil/skills/check-upstream-responses/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wr-itil:check-upstream-responses
-description: Poll upstream issues we've filed via `/wr-itil:report-upstream` and surface new comments, state changes, or label changes since last check. Reads `## Reported Upstream` back-link sections in local problem tickets, queries `gh issue view` (read-only), diffs against `docs/problems/.outbound-responses-cache.json`, and appends an audit-log entry to `docs/audits/outbound-responses-log.md`. Outbound symmetric counterpart to ADR-062's inbound discovery pipeline (P249 Phase 1).
+description: Poll upstream issues and pull requests we've filed via `/wr-itil:report-upstream` and surface new comments or reviews, state changes, or label changes since last check. Reads `## Reported Upstream` back-link sections in local problem tickets, queries GitHub read-only, diffs against `docs/problems/.outbound-responses-cache.json`, and appends an audit-log entry to `docs/audits/outbound-responses-log.md`. Outbound symmetric counterpart to ADR-062's inbound discovery pipeline (P249 Phase 1).
 allowed-tools: Read, Edit, Write, Bash, Glob, Grep
 ---
 
@@ -14,14 +14,14 @@ This is **Phase 1** of P249. Phase 1 covers the **us-as-upstream-reporter** half
 
 In scope:
 - Scan `docs/problems/**/*.md` for `## Reported Upstream` back-link sections (the contract section written by `/wr-itil:report-upstream` Step 7 — see [ADR-024](../../../../docs/decisions/024-cross-project-problem-reporting-contract.proposed.md) Step 7).
-- For each ticket with a back-link, extract the `- **URL**:` line and poll the upstream issue via `gh issue view <url> --json comments,state,labels,updatedAt`.
+- For each ticket with a back-link, extract the `- **URL**:` line and poll the upstream artefact. Read the `- **Disclosure path**:` line to pick the subcommand: any pull-request path uses `gh pr view` plus a read-only `gh api` call for inline review comments; anything else, **including an absent line**, uses `gh issue view`. Absent means a ticket written before ADR-117, which could only have been filed as a public issue — so it is read as an issue, with no probe.
 - Diff against `docs/problems/.outbound-responses-cache.json` (cache file mirroring the inbound `.upstream-cache.json` shape per ADR-031 § "Cache files live under docs/problems/").
-- Surface five response classes: NEW (new comments), STATE (state change), LABEL (label change), NONE (no change), FAIL (gh poll error).
+- Surface five response classes: NEW (new comments, reviews, or other upstream activity), STATE (state change), LABEL (label change), NONE (no change), FAIL (gh poll error).
 - Update the cache file with the latest seen state.
 - Append a timestamped pass entry to `docs/audits/outbound-responses-log.md` (audit-log mirroring `docs/audits/inbound-discovery-log.md` per ADR-062's audit-log surface contract).
 
 Out of scope:
-- Posting comments back to the upstream issue. The skill is **read-only externally** — does not trip ADR-028's external-comms gate.
+- Posting comments back to the upstream issue or pull request. The skill is **read-only externally** — does not trip ADR-028's external-comms gate.
 - Auto-transitioning local ticket lifecycle based on upstream state change (that is P080's bidirectional update axis, separate).
 - Polling against the inbound-discovery channels (`docs/problems/.upstream-channels.json`). That is the inverse axis, owned by `/wr-itil:review-problems` Step 4.5 per ADR-062.
 - Phase 2 external-reporter-as-our-reporter surface (deferred).
@@ -43,7 +43,7 @@ Out of scope:
 
 This skill is **AFK-safe by construction**:
 
-- Read-only `gh issue view` calls — does NOT fire ADR-028 external-comms gate.
+- Read-only `gh issue view`, `gh pr view`, and pull-request review-comment `gh api` calls — none fires ADR-028's external-comms gate.
 - No `AskUserQuestion` calls — five flag-based knobs (`--problems-dir`, `--cache-file`, `--audit-log`, `--ticket`, `--force-recheck`) are the user-direction surface per CLAUDE.md `act on obvious, AskUserQuestion for ambiguous, NEVER prose-ask` (P085).
 - Partial-failure exit code (2) lets AFK orchestrators distinguish "some upstream URLs were unreachable" from "everything broke" without halting the loop.
 
@@ -63,7 +63,7 @@ The script:
 
 1. Walks `<problems-dir>` (both flat layout `<NNN>-*.<state>.md` AND per-state subdir layout `<state>/<NNN>-*.md` per RFC-002 dual-tolerant migration).
 2. For each ticket file, extracts the `## Reported Upstream` URL line. Tickets without that section are silently skipped.
-3. For each URL, calls `gh issue view <url> --json comments,state,labels,updatedAt`.
+3. For each URL, calls `gh issue view --json comments,state,labels,updatedAt` or `gh pr view --json comments,reviews,state,labels,updatedAt` (chosen by the disclosure path). Pull requests also fetch inline review comments through `gh api`. The response count and response-specific timestamp combine all three response surfaces; parent metadata changes do not masquerade as review activity. A merged pull request reports `state=MERGED`, distinct from `CLOSED`, so a rejected one is not recorded as a resolution.
 4. Compares the response against the cached entry for that ticket and emits one of: NEW / STATE / LABEL / NONE / FAIL.
 5. Updates the cache file and appends an audit-log entry.
 
@@ -78,7 +78,7 @@ Exit codes:
 Read the stdout output and summarise the response classes in chat for the user. The audit-log is the durable surface — the agent's inline summary is the in-session affordance. Do NOT re-dump the full stdout; lead with the most-important classes:
 
 - STATE changes (upstream state OPEN → CLOSED / REOPENED) — most actionable; usually a verification signal.
-- NEW comments (delta count > 0) — second-most actionable; may carry triage labels, follow-up questions, or fix confirmation.
+- NEW responses or activity — second-most actionable; may carry comments, reviews, inline review comments, follow-up questions, or fix confirmation. A zero response delta means an existing response was edited.
 - LABEL changes — informational; signals maintainer triage activity.
 - NONE — quiet; only mention the count, not each ticket.
 - FAIL — call out per-ticket reasons so the user can investigate (URL changed, repo renamed, auth issue).
@@ -110,7 +110,7 @@ Three invocation surfaces:
 
 This skill's contract holds when:
 
-1. The script `packages/itil/scripts/check-upstream-responses.sh` is read-only externally — only `gh issue view` (no `gh issue comment`, no `gh issue create`, no `gh api`).
+1. The script `packages/itil/scripts/check-upstream-responses.sh` is read-only externally — `gh issue view`, `gh pr view`, and a pull-request review-comment `gh api` read only; it makes no comment, create, edit, close, or write API call.
 2. The script extracts the URL from `## Reported Upstream` sections matching the format `- **URL**: <url>` per ADR-024 Step 7's back-link contract.
 3. After a successful pass, the cache file exists, is valid JSON, and contains a `tickets.<P<NNN>>` entry for every polled ticket.
 4. After a successful pass, the audit-log file exists and has a new `## YYYY-MM-DDTHH:MM:SSZ` heading appended.

--- a/packages/itil/skills/manage-problem/SKILL.md
+++ b/packages/itil/skills/manage-problem/SKILL.md
@@ -70,7 +70,7 @@ To un-park: `git mv` back to `docs/problems/open/<NNN>-<title>.md` (or `docs/pro
 
 **Verification Pending problems** are also excluded from WSJF ranking — their remaining work is user-side verification, not dev effort. They appear in a dedicated "Verification Queue" section in review output so the user can see what's waiting on them without mixing with dev-work ranking. See step 9c for the queue layout.
 
-**Allowed optional appendages**: a problem ticket file may carry a `## Reported Upstream` section appended after the standard sections. This is written by the `/wr-itil:report-upstream` skill (per ADR-024 Confirmation criterion 3a) and records the upstream issue or advisory URL, the matched template, and the disclosure path. The presence or absence of this section does not affect WSJF ranking or status transitions.
+**Allowed optional appendages**: a problem ticket file may carry a `## Reported Upstream` section appended after the standard sections. This is written by the `/wr-itil:report-upstream` skill (per ADR-024 Confirmation criterion 3a) and records the upstream URL — an issue, a pull request (per ADR-117), or an advisory — plus the matched template and the disclosure path. The presence or absence of this section does not affect WSJF ranking or status transitions.
 
 **Test-driven resolution:** When root cause is identified, create a failing test that reproduces the problem. Skip/disable the test if a feature-disabling workaround is applied. Re-enable the test when the permanent fix is implemented — the test passing confirms resolution.
 

--- a/packages/itil/skills/report-upstream/SKILL.md
+++ b/packages/itil/skills/report-upstream/SKILL.md
@@ -6,13 +6,13 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Skill, Agen
 
 # Report Upstream — Cross-Project Problem-Reporting Skill
 
-File a local `docs/problems/<NNN>` ticket as an issue (or private security advisory) against an upstream repository. Discover upstream issue templates, fall through to a structured default when none exist, route security-classified tickets via the upstream's `SECURITY.md`, and back-write a cross-reference into the local ticket.
+Report a local `docs/problems/<NNN>` ticket upstream. **Prefer opening a pull request when the upstream accepts pull requests**; fall back to filing an issue otherwise (or a private security advisory when the ticket is security-classified). Discover upstream templates, fall through to a structured default when none exist, route security-classified tickets via the upstream's `SECURITY.md`, and back-write a cross-reference into the local ticket.
 
 This skill implements the contract documented in [ADR-024](../../../docs/decisions/024-cross-project-problem-reporting-contract.proposed.md) (Cross-project problem-reporting contract). All step numbering below maps 1:1 to ADR-024 Decision Outcome.
 
 [ADR-033](../../../docs/decisions/033-report-upstream-classifier-problem-first.proposed.md) (Report-upstream classifier is problem-first) partially supersedes ADR-024 Decision Outcome **Steps 3 and 5 only** — the classifier is problem-first with best-fit backward-compat fallback (per Step 3 below), and the structured default body is problem-shaped (per Step 5 below). ADR-024 Steps 1, 2, 4, 6, 7, 8 and all Consequences / Confirmation clauses remain in force unchanged.
 
-The **ADR-024 amendment of 2026-04-25 (P070)** adds Step 4b (dedup check — own re-run + third-party search via `gh issue list --search` + inline LLM semantic match) and Step 5c (comment path — `gh issue comment` with cross-reference body when dedup match found). The maintainer-annoyance risk evaluator named in the P070 Direction decision is deferred to compose with the `wr-risk-scorer:external-comms` subagent declared in ADR-028 (per ADR-028 line 117 — third-evaluator extension point); the AFK auto-comment branch is on the interim **static heuristic** described in Step 4b until that evaluator lands. See Step 4b below.
+The **ADR-024 amendment of 2026-04-25 (P070)** adds Step 4b (dedup check — own re-run + third-party search across issues and pull requests, followed by inline LLM semantic matching) and Step 5c (kind-aware comment path). AFK comments use the shipped `wr-risk-scorer:external-comms` gate; unresolved above-appetite prose is queued without halting the orchestrator.
 
 ## Invocation
 
@@ -44,7 +44,7 @@ This skill files reports against an upstream's intake surface. Its reciprocal �
 
 ## Voice-tone gate interaction (ADR-028)
 
-The skill's `gh issue create` (Step 5) and `gh api repos/.../security-advisories` (Step 6) calls are **on the gated surface list per [ADR-028](../../../docs/decisions/028-voice-tone-gate-external-comms.proposed.md)** (Voice-tone gate on external communications). Expected behaviour during these tool calls:
+The skill's `gh issue create` (Step 5), `gh pr create` (Step 5b), `gh issue comment` / `gh pr comment` (Step 5c) and `gh api repos/.../security-advisories` (Step 6) calls are **on the gated surface list per [ADR-028](../../../docs/decisions/028-voice-tone-gate-external-comms.proposed.md)** (Voice-tone gate on external communications). Expected behaviour during these tool calls:
 
 1. The voice-tone gate fires `PreToolUse:Bash` with a deny-plus-delegate response.
 2. The hook delegates to `wr-voice-tone:agent` to review the drafted body for brand-voice + tone alignment against `docs/VOICE-AND-TONE.md`.
@@ -53,6 +53,13 @@ The skill's `gh issue create` (Step 5) and `gh api repos/.../security-advisories
 The skill should treat this transient deny-plus-delegate as the expected path, not as an error. The voice-tone agent's review covers only the prose body of the upstream report (issue body, advisory body); structural fields (template field IDs, plugin name, version) are not in voice-tone scope.
 
 If `wr-voice-tone:agent` is not installed in the project, the gate is dormant and the skill proceeds without delegation.
+
+**A pull request carries two outbound surfaces; only one of them is gated.** The prose must be reviewed, but the shipped hook extracts only the `--body` value. Before `gh pr create`, explicitly send the **combined title and body** through `wr-risk-scorer:external-comms` and `wr-voice-tone:external-comms`; the hook then enforces the body review on the command itself. The **diff is not gated by anything**. Nothing in this repo scores a diff against an upstream's policy or contribution standards. Read the diff yourself before opening the pull request; that gap is tracked as P497 and is deliberately not closed by this skill.
+
+Two mechanical notes so a re-route is not mistaken for a defect:
+
+- The surface label is part of the gate's marker key. A body first reviewed as an issue and then re-routed to a pull request misses its marker and pays a second full review by both evaluators, even though the prose is byte-identical. Expected, not a bug.
+- The gate's surface regex anchors on a command start, a `;`, an `&&` or a `||`. A **piped** invocation (`… | gh pr create`) does not match and the gate silently no-ops. Invoke `gh pr create` in an anchor-matching form.
 
 ## Steps
 
@@ -73,12 +80,17 @@ Extract:
 
 If the ticket is not found, halt with a clear error: `Error: local ticket P<NNN> not found in docs/problems/. Did you mean a different ID?`
 
-### 2. Discover upstream issue templates
+### 2. Discover upstream metadata, contribution guidance, and issue templates
 
 ```bash
 UPSTREAM_OWNER_REPO=$(echo "$UPSTREAM_URL" | sed -E 's|https?://github.com/([^/]+/[^/]+)(/.*)?|\1|')
+REPO_JSON=$(gh api "repos/${UPSTREAM_OWNER_REPO}")
 TEMPLATES_JSON=$(gh api "repos/${UPSTREAM_OWNER_REPO}/contents/.github/ISSUE_TEMPLATE" 2>/dev/null)
+CONTRIBUTING_MD=$(gh api "repos/${UPSTREAM_OWNER_REPO}/contents/CONTRIBUTING.md" --jq '.content' 2>/dev/null | base64 -d)
+PR_TEMPLATE_MD=$(gh api "repos/${UPSTREAM_OWNER_REPO}/contents/.github/PULL_REQUEST_TEMPLATE.md" --jq '.content' 2>/dev/null | base64 -d)
 ```
+
+If the conventional contribution files are absent, also try `.github/CONTRIBUTING.md`, `.github/pull_request_template.md`, and `docs/PULL_REQUEST_TEMPLATE.md`. A 404 for any optional file means absent; cache successful responses for Steps 4c and 5b. A failure fetching `REPO_JSON` is fatal because its `archived`, `disabled`, and `default_branch` fields govern the route and checkout.
 
 Parse the response:
 - HTTP 200 with a JSON array → upstream has templates. List the names + types (`.yml` for forms, `.md` for legacy markdown templates).
@@ -120,13 +132,56 @@ The local ticket is **security-classified** if any of:
 - The ticket body has a `## Security classification` section.
 - The CLI `--classification security` argument was passed.
 
-If security-classified, route to Step 6. Otherwise, route to Step 4b (dedup check) before Step 5 (public-issue path).
+If security-classified, route to Step 6. Otherwise, route to Step 4b (dedup check), then Step 4c (choose the outbound artefact), then Step 5 or Step 5b.
+
+Security classification is checked **first and wins outright**. A security-classified ticket never reaches Step 4c, so it can never be routed to a pull request — the private disclosure path in Step 6 stands exactly as it is.
+
+### 4c. Choose the outbound artefact — pull request or issue (ADR-117)
+
+This step is governed by [ADR-117](../../../docs/decisions/117-prefer-an-upstream-pull-request-over-an-issue.proposed.md) (Prefer an upstream pull request over an issue when the upstream accepts pull requests), which adds this branch alongside ADR-024's confirmed reporting contract and ahead of Step 5.
+
+**Prefer a pull request. File an issue when one of the four fallbacks below applies.**
+
+#### The predicate is "does this upstream accept pull requests"
+
+It is **not** "do we have write access". Fork-and-PR is the ordinary way a third party contributes, and it needs no permission we have to negotiate for. Most adopters of this plugin are consumers of their dependencies, not owners of them — a write-access predicate would make this whole branch a no-op for exactly the case the skill was written for.
+
+Read the signal from the discovery calls Step 2 makes:
+
+- The `repos/<owner>/<repo>` payload's `archived` and `disabled` flags. Either one true → the upstream is not accepting contributions.
+- The presence of `CONTRIBUTING.md`, or of a pull-request template fetched in Step 2. Either is positive evidence that pull requests are wanted.
+- An explicit statement in `CONTRIBUTING.md` that the project does not accept outside contributions.
+
+**On an absent or ambiguous signal, default to "accepts".** Do not escalate through a probe ladder to prove acceptance — a refuse-unless-proven predicate is the same failure mode ADR-024 already rejected when it declined to refuse upstreams that ship no issue templates. State which signal was read, or say the signal was absent and the default applied. Do not write "upstream likely accepts pull requests".
+
+#### File an issue instead when
+
+1. **The upstream does not accept contributions.** Archived, disabled, or says so.
+2. **The fix needs a design decision that is the maintainers' to make.** More than one defensible approach, and picking between them is their call, not ours.
+3. **The ticket is security-classified.** Already routed at Step 4 — this fallback records that the routing exists, and it is Step 6's private path that runs, not this one. Nothing here re-asserts the pre-P270 blanket ban.
+4. **There is no defensible fix in hand.** A symptom, or even a confident diagnosis, is not a change we can responsibly author in a codebase we do not know.
+
+#### Fallback 4 is decided silently — never ask the reporter
+
+The reporter describes a symptom. That is the whole of their obligation and this decision must not touch it. **Do not raise an `AskUserQuestion` about whether to write a patch.** The skill already carries two interactive gates (Step 4b dedup, Step 6 missing-`SECURITY.md`); a third would push intake past the couple of minutes beyond which a report simply gets abandoned, and it would be asking the reporter to ratify a judgement the agent is there to make.
+
+The preference is a preference. It never converts the reporter into a patch author. The added cost lands on agent time and token budget, not on anyone's attention.
+
+#### Draft the issue body first; the pull request is an upgrade of it
+
+Compose the Step 5 issue body **before** attempting the pull request, always. Then attempt the pull request. If the attempt fails for any reason — fork refused, patch will not apply, upstream tests red, effort budget spent — **file the already-drafted issue** rather than aborting.
+
+Without this, a failed pull-request attempt loses a report that the issue-only path would have filed, which is strictly worse than not having tried.
+
+#### Effort budget
+
+Spend at most **20 minutes of wall-clock and 3 attempts** on getting a working patch. Past that, fall back to fallback 4 and file the drafted issue. The budget is a real number rather than a judgement call because an open-ended "author a fix in an unfamiliar codebase" is how a loop burns a quota and how an idle guard that measures progress in commits kills a session doing legitimate work.
 
 ### 4b. Dedup check (P070)
 
-This step is governed by the [ADR-024](../../../docs/decisions/024-cross-project-problem-reporting-contract.proposed.md) 2026-04-25 amendment, which adds dedup checking to the Decision Outcome step list (P070). Two duplication windows close at the same insertion point: own re-run (4b.1) and third-party search (4b.2). Both branches share the same AskUserQuestion surface and the same AFK halt-and-save behaviour.
+This step is governed by the [ADR-024](../../../docs/decisions/024-cross-project-problem-reporting-contract.proposed.md) 2026-04-25 amendment, which adds dedup checking to the Decision Outcome step list (P070). Two duplication windows close at the same insertion point: own re-run (4b.1) and third-party search (4b.2). Both branches share the same AskUserQuestion surface and AFK risk-gated queue-and-continue behaviour.
 
-> **Serves**: JTBD-004 (cross-repo coordination — dedup is the difference between coordination and spam), JTBD-001 (solo developer "without slowing down" — dedup protects the user from policing upstream duplicates manually), JTBD-006 (AFK persona — halt-and-surface protects loops from duplicate-firing), JTBD-101 (clear pattern — pattern ships without a duplication hole).
+> **Serves**: JTBD-004 (cross-repo coordination — dedup is the difference between coordination and spam), JTBD-001 (solo developer "without slowing down" — dedup protects the user from policing upstream duplicates manually), JTBD-006 (AFK persona — risk-gated queue-and-continue avoids duplicate firing), JTBD-101 (clear pattern — pattern ships without a duplication hole).
 
 #### 4b.1. Own re-run check
 
@@ -134,8 +189,13 @@ Detect whether the local ticket already records a previous upstream report. The 
 
 ```bash
 LOCAL_URL=$(grep -A5 '^## Reported Upstream' "$LOCAL_TICKET" | grep -oE 'https?://[^ )]+' | head -1)
+LOCAL_DISCLOSURE=$(grep -A5 '^## Reported Upstream' "$LOCAL_TICKET" | sed -n 's/^- \*\*Disclosure path\*\*: //p' | head -1)
+case "$(printf '%s' "$LOCAL_DISCLOSURE" | tr '[:upper:]' '[:lower:]')" in
+  *pull*request*) LOCAL_KIND="pull-request" ;;
+  *) LOCAL_KIND="issue" ;;
+esac
 if [ -n "$LOCAL_URL" ]; then
-  echo "Local ticket P${LOCAL_ID} already records an existing upstream report: $LOCAL_URL"
+  echo "Local ticket P${LOCAL_ID} already records an existing upstream ${LOCAL_KIND}: $LOCAL_URL"
   # Branch interactive vs AFK below.
 fi
 ```
@@ -146,10 +206,10 @@ fi
 - `multiSelect: false`
 - Options:
   1. `Halt — local ticket already records ${LOCAL_URL}` (Recommended) — abort the invocation; the existing report is current.
-  2. `Comment on the existing upstream report` — route to Step 5c with the existing URL's issue number; appropriate when new evidence has emerged since the previous report.
+  2. `Comment on the existing upstream report` — route to Step 5c with the existing URL's number and `${LOCAL_KIND}`; appropriate when new evidence has emerged since the previous report.
   3. `File a new upstream issue anyway (override)` — explicit override after user has reviewed the existing record and judged the second filing warranted (e.g. previous report was closed without resolution and a fresh tracker is needed).
 
-**AFK / non-interactive branch** — apply the **interim static heuristic** (no subagent dispatch; the maintainer-annoyance risk evaluator is deferred per ADR-028 line 117 — see "AFK static heuristic" below). Default action: halt and save the drafted report to the local ticket's `## Queued Upstream Report` section; do NOT auto-comment. The static heuristic remains in place until `wr-risk-scorer:external-comms` ships, at which point the AFK branch wires the gate combination (maintainer-annoyance + leak gate, both within appetite) per the ticket Direction decision (2026-04-21).
+**AFK / non-interactive branch** — apply the external-communications gate in the AFK behaviour summary. Below-appetite prose comments on the existing `${LOCAL_KIND}`; unresolved above-appetite prose is queued and the orchestrator continues.
 
 #### 4b.2. Third-party search
 
@@ -158,26 +218,48 @@ Detect whether a different reporter (or another agent in a parallel session) has
 ```bash
 # Stage 1: gh-search pre-filter on title keywords (cheap, ~500ms-2s).
 KEYWORDS=$(extract_3-5_keywords_from "$LOCAL_TICKET_TITLE + $LOCAL_TICKET_DESCRIPTION")
-MATCHES=$(gh issue list \
+ISSUE_MATCHES=$(gh issue list \
   --repo "$UPSTREAM_OWNER_REPO" \
   --state all \
   --search "$KEYWORDS" \
   --json number,title,state,url \
   --limit 10)
+
+# ADR-117: `gh issue list` does NOT return pull requests. Now that this skill
+# opens pull requests, searching issues alone leaves the whole pull-request
+# window open — including against pull requests we opened ourselves.
+PR_MATCHES=$(gh pr list \
+  --repo "$UPSTREAM_OWNER_REPO" \
+  --state all \
+  --search "$KEYWORDS" \
+  --json number,title,state,url \
+  --limit 10)
+
+MATCHES=$(jq -cn \
+  --argjson issues "$ISSUE_MATCHES" \
+  --argjson prs "$PR_MATCHES" \
+  '($issues | map(. + {kind: "issue"})) +
+   ($prs | map(. + {kind: "pull-request"}))')
 ```
+
+Carry the artefact kind alongside each candidate. Step 5c needs it to pick between `gh issue comment` and `gh pr comment`, and the user needs it to judge a match — "already fixed in an open pull request" is a different situation from "already reported in an open issue".
 
 For each candidate returned by Stage 1, fetch the full body and run **Stage 2 — inline LLM semantic judgement**:
 
 ```bash
 # Stage 2: per-candidate body fetch + inline classification.
-for n in $(echo "$MATCHES" | jq -r '.[].number'); do
-  CANDIDATE=$(gh issue view "$n" --repo "$UPSTREAM_OWNER_REPO" --json title,body,state,url)
+while IFS=$'\t' read -r kind n; do
+  if [ "$kind" = "pull-request" ]; then
+    CANDIDATE=$(gh pr view "$n" --repo "$UPSTREAM_OWNER_REPO" --json title,body,state,url)
+  else
+    CANDIDATE=$(gh issue view "$n" --repo "$UPSTREAM_OWNER_REPO" --json title,body,state,url)
+  fi
   # Inline LLM judgement: read {local ticket Description + Symptoms, candidate title + body}
   # and return one of: same-problem | different-problem | uncertain.
   # No subagent dispatch — Direction decision 2026-04-21 pins inline classification
   # for simplicity. Promotion to a `wr-itil:dedup-check` subagent is a future
   # ADR amendment if architect review later flags context-isolation concerns.
-done
+done < <(echo "$MATCHES" | jq -r '.[] | [.kind, .number] | @tsv')
 ```
 
 Notes on inline LLM classification:
@@ -197,31 +279,23 @@ If Stage 2 produces one or more `same-problem` matches, surface them to the user
 
 `uncertain` matches surface alongside `same-problem` matches with their verdict labelled, so the user can review. The skill never auto-resolves an `uncertain` verdict.
 
-**AFK / non-interactive branch** — apply the same interim static heuristic as 4b.1: halt and save the drafted report to the local ticket's `## Queued Upstream Report` section. The third-party-match auto-comment path requires the deferred `wr-risk-scorer:external-comms` gate (maintainer-annoyance + leak), so the AFK branch must NOT auto-comment under the static heuristic.
+**AFK / non-interactive branch** — apply the external-communications gate in the AFK behaviour summary, preserving the matched artefact kind. Below-appetite prose comments on the matching issue or pull request; unresolved above-appetite prose is queued and the orchestrator continues.
 
-#### AFK static heuristic (interim, until `wr-risk-scorer:external-comms` ships)
-
-The Direction decision (2026-04-21) pins the AFK auto-comment branch on **two gates passing together**: the maintainer-annoyance risk evaluator AND the P064 external-comms leak gate, both within RISK-POLICY.md's commit-layer appetite (Low, ≤4/25). Neither gate exists yet — ADR-028 declares the `wr-risk-scorer:external-comms` subagent type but P064's implementation is open at WSJF 3.0 (Effort L), and the maintainer-annoyance evaluator was deferred by architect review on P070 to compose with the same subagent rather than ship as a separate evaluator (per ADR-028 line 117 — *"Third evaluator (licence-compliance, etc.) adding to the same gate — when it emerges, amend this ADR's evaluator list and the composite marker's `evaluator_set` component; no new ADR expected."*).
-
-**Static heuristic, valid until both gates ship**: in AFK mode, both 4b.1 and 4b.2 default to **halt and save the drafted report**. No auto-comment, no auto-file. The drafted report is appended to the local ticket's `## Queued Upstream Report` section so the user can review and act manually on return. This matches JTBD-006's "does not trust the agent to make judgement calls" stance — the conservative default is the right interim behaviour.
-
-**Re-wire trigger**: when `wr-risk-scorer:external-comms` lands (ADR-028 implementation, P064 closure), amend this section to invoke both evaluators and proceed with auto-comment ONLY when both verdicts return PASS within appetite. Update the AFK behaviour summary table accordingly. Until then, the static heuristic stands.
-
-**Queued Upstream Report save format** (used by both 4b.1 and 4b.2 AFK halts; mirrors the security-path halt pattern from Step 6 per ADR-024 Consequences lines 116, 123. **Renamed from `## Drafted Upstream Report` per ADR-024 2026-06-04 second-amendment ratification (c)** — same shape; new name reflects post-amendment semantics, queue-for-review-on-return not loop-stopping halt-and-save):
+**Queued Upstream Report save format** (used by both 4b.1 and 4b.2 when risk cannot be reduced within appetite):
 
 ```markdown
 ## Queued Upstream Report
 
 - **Drafted**: <YYYY-MM-DD>
 - **Target upstream**: <upstream-repo-url>
-- **Halt reason**: dedup match (own re-run | third-party `same-problem`) — interim static heuristic awaiting `wr-risk-scorer:external-comms` (ADR-028 / P064)
+- **Queue reason**: dedup match (own re-run | third-party `same-problem`) — external-communications risk remains above appetite
 - **Matched URL(s)**: <existing-issue-or-report-URL(s)>
 - **Drafted body**:
 
-  <the body that would have been posted as a `gh issue comment` or `gh issue create`, ready for manual copy-paste review>
+  <the body that would have been posted as a comment or new report, ready for review>
 ```
 
-The halt is a loop-stopping event for AFK orchestrators — same pattern as the security-path halt-and-surface branch — so the user sees the dedup match on return rather than the orchestrator silently auto-commenting.
+Queue an `outstanding_questions` entry and include the queued report in the progress summary; do not halt the orchestrator.
 
 ### 5. Public-issue path
 
@@ -395,25 +469,118 @@ Reported from <downstream-repo-url>/<local-ticket-relative-path>
 This issue is tracked locally as P<NNN> in the downstream project's `docs/problems/` directory.
 ```
 
+Retain the completed issue-shaped body separately so a failed pull-request attempt cannot overwrite its fallback:
+
+```bash
+ISSUE_BODY="${FILLED_BODY}"
+```
+
 Open the issue:
 
 ```bash
 gh issue create \
   --repo "${UPSTREAM_OWNER_REPO}" \
   --title "${TITLE_PREFIXED_BY_TEMPLATE}" \
-  --body "${FILLED_BODY}"
+  --body "${ISSUE_BODY}"
 ```
 
 Do **not** pass `--label` on this call (P207). Labels are supplied by the matched template's YAML `labels:` frontmatter and applied by GitHub when the issue form is submitted; passing `--label <name>` for a label that has not been pre-created on the upstream repo causes `gh issue create` to hard-fail with `could not add label: '<name>' not found`. The flag is redundant when the matched template carries `labels:` and a hard-fail surface when it does not. If the upstream has no matched template at all (structured-default body path, Step 3 preference order item 7), omit labels entirely — leave triage to the upstream maintainer's existing routing.
 
 Capture the returned issue URL. The voice-tone gate per ADR-028 may delegate-and-retry; treat this as expected (see "Voice-tone gate interaction" above). Proceed to Step 7 once the issue is created.
 
+### 5b. Pull-request path (ADR-117)
+
+Reached when Step 4c chose a pull request. The Step 5 issue body is already drafted at this point and is held as the fallback.
+
+#### The body defers to the upstream's own template
+
+ADR-033's structured default is a **problem report** — Description, Symptoms, Workaround, Affected plugin, Frequency, Versions, Evidence, Cross-reference. That shape is incoherent on a pull request, where the diff already resolves the symptoms it would recite. ADR-033's classifier and its structured default remain unchanged and in force on the issue branch; only this branch differs.
+
+1. Fetch `.github/PULL_REQUEST_TEMPLATE.md` (also try `.github/pull_request_template.md` and `docs/PULL_REQUEST_TEMPLATE.md`). **If one exists, fill it.** This is the same posture as respecting the upstream's curated issue templates, applied to a second artefact kind.
+2. If none exists, use the reduced shape below — rationale plus cross-reference, not a problem report:
+
+```markdown
+## What this changes
+
+<one paragraph: the change, in the upstream's own vocabulary>
+
+## Why
+
+<the problem this fixes, stated as the upstream experiences it — not as our
+ticket experiences it. Link an existing upstream issue if one covers it.>
+
+## Cross-reference
+
+Reported from <downstream-repo-url>/<local-ticket-relative-path>, where this
+is tracked as P<NNN>.
+```
+
+Keep it short. A pull request body that recites symptoms the diff already answers reads as noise to a reviewer.
+
+Retain this separately as `PR_BODY`; never overwrite `ISSUE_BODY`.
+
+#### Show the diff before opening it
+
+The external-comms gate forces a turn here to review the prose. Nothing reviews the **patch** — no surface in this repo reads a diff against an upstream's conventions (P497). So make the patch visible at the stop that is already happening, rather than letting it go out unseen:
+
+1. Print the full patch to the session — `git diff` against the upstream's base branch — immediately before `gh pr create`.
+2. State in the drafted body which of the upstream's own convention files you read and complied with: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, a linter config, a CI workflow. Name the file. If you read none, say so.
+
+This adds no `AskUserQuestion` and does not reopen Step 4c's silent determination. It converts an invisible diff into a visible one at a turn the reviewer is already stopped on, which is the cheapest control available until P497 is closed.
+
+#### Build and open it from an isolated upstream checkout
+
+Do not author the upstream patch in the downstream project's working tree. Use a temporary clone, create one branch, apply the smallest defensible patch, run the upstream's documented checks, commit it, and push it to a fork (or directly only when write access is already available).
+
+```bash
+UPSTREAM_BASE=$(echo "$REPO_JSON" | jq -r '.default_branch')
+UPSTREAM_CHECKOUT=$(mktemp -d)
+BRANCH="windyroad/p${LOCAL_ID}-$(printf '%s' "$TITLE" | tr '[:upper:] ' '[:lower:]-' | tr -cd '[:alnum:]-' | cut -c1-40)"
+
+PR_URL=$(
+  gh repo clone "$UPSTREAM_OWNER_REPO" "$UPSTREAM_CHECKOUT/repo" -- --filter=blob:none
+  cd "$UPSTREAM_CHECKOUT/repo"
+  git switch -c "$BRANCH" "origin/$UPSTREAM_BASE"
+
+  # Apply the patch, run the upstream's documented checks, then:
+  git add --all
+  git commit -m "fix: <upstream-facing summary>"
+  gh repo fork "$UPSTREAM_OWNER_REPO" --remote --remote-name fork
+  git push --set-upstream fork "$BRANCH"
+
+  GH_USER=$(gh api user --jq .login)
+  git diff "origin/$UPSTREAM_BASE...HEAD" >&2
+  gh pr create \
+    --repo "${UPSTREAM_OWNER_REPO}" \
+    --base "${UPSTREAM_BASE}" \
+    --head "${GH_USER}:${BRANCH}" \
+    --title "${TITLE}" \
+    --body "${PR_BODY}"
+)
+```
+
+The command substitution is a subshell, so Step 7 resumes in the downstream checkout. Immediately before `gh pr create`, explicitly review `${TITLE}` plus `${PR_BODY}` together through both external-communications evaluators. Do not rely on the command hook for the title: it extracts the body only.
+
+Invoke it at a command start or after `;` / `&&` / `||`, never through a pipe, or the external-comms gate does not match the surface and silently skips the review. Do not pass `--label` for the same reason Step 5 does not (P207).
+
+Capture the returned pull-request URL and proceed to Step 7, recording disclosure path `pull request`.
+
+If the attempt fails at any point, file the drafted Step 5 issue instead and record `public issue`. A failed pull request must never cost us the report.
+
 ### 5c. Comment path (P070)
 
 Used when Step 4b's dedup check (own re-run or third-party search) finds a match AND the user picks the "comment instead" option. Skips `gh issue create` and posts a cross-reference comment on the existing upstream issue:
 
+**Branch on what the dedup check actually matched (ADR-117).** Step 4b.2 now searches pull requests as well as issues, so the match may be either. `gh issue comment` errors on a pull request:
+
 ```bash
-gh issue comment "${EXISTING_ISSUE_NUMBER}" \
+# Issue match:
+gh issue comment "${EXISTING_NUMBER}" \
+  --repo "${UPSTREAM_OWNER_REPO}" \
+  --body "${COMMENT_BODY}"
+
+# Pull-request match:
+gh pr comment "${EXISTING_NUMBER}" \
   --repo "${UPSTREAM_OWNER_REPO}" \
   --body "${COMMENT_BODY}"
 ```
@@ -437,7 +604,7 @@ Empty subsections are skipped — the comment should add information, not restat
 
 The voice-tone gate per ADR-028 also fires on `gh issue comment` (per the canonical hook's regex list at ADR-028 line 61); treat the deny-plus-delegate-and-retry as expected, same as Step 5.
 
-Capture the returned comment URL (gh prints `https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<id>`). The Step 7 back-write records this as the cross-reference URL with disclosure path `commented-on-existing-issue`. Proceed to Step 7.
+Capture the returned comment URL. The Step 7 back-write records an issue match as `commented-on-existing-issue` and a pull-request match as `commented-on-existing-pull-request`. Proceed to Step 7.
 
 ### 6. Security path
 
@@ -489,9 +656,11 @@ After the upstream issue or advisory is created (or drafted-and-saved in the sec
    - **URL**: <upstream-issue-or-advisory-url>
    - **Reported**: <YYYY-MM-DD>
    - **Template used**: <template-name-or-"structured default">
-   - **Disclosure path**: <public issue | security advisory | drafted-and-saved (mailbox / out-of-band) | commented-on-existing-issue (Step 5c, P070)>
+   - **Disclosure path**: <public issue | pull request (Step 5b, ADR-117) | security advisory | drafted-and-saved (mailbox / out-of-band) | commented-on-existing-issue (Step 5c, P070) | commented-on-existing-pull-request (Step 5c, ADR-117)>
    - **Cross-reference confirmed**: <yes/no — true once the upstream issue body contains the local ticket reference>
    ```
+
+The `pull request` and `commented-on-existing-pull-request` values are what `/wr-itil:check-upstream-responses` and `/wr-itil:update-upstream` read to pick `gh pr view` and `gh pr comment` over their issue equivalents. Write them exactly; an absent line is read as `public issue`, which is correct for tickets predating ADR-117 but wrong for a pull request.
 
 ### 8. Commit per ADR-014
 
@@ -505,14 +674,15 @@ If the cumulative pipeline risk lands above appetite and `AskUserQuestion` is un
 
 ## AFK behaviour summary
 
-Five distinct AFK branches; **per the ADR-024 2026-06-04 (P270) amendment, ALL pre-commit branches now route through the `wr-risk-scorer:external-comms` gate** (ADR-028) — below-appetite proceeds, above-appetite risk-reduces then queues. The legacy "halt the orchestrator" semantics for dedup-match and security-path-without-declared-channel are **superseded** by queue-and-continue per P352:
+Six distinct AFK branches; **per the ADR-024 2026-06-04 (P270) amendment, ALL pre-commit branches now route through the `wr-risk-scorer:external-comms` gate** (ADR-028) — below-appetite proceeds, above-appetite risk-reduces then queues. The legacy "halt the orchestrator" semantics for dedup-match and security-path-without-declared-channel are **superseded** by queue-and-continue per P352:
 
 | Branch | AFK behaviour | Authority |
 |---|---|---|
 | Public-issue path (Step 5) | Score drafted prose via `wr-risk-scorer:external-comms` (ADR-028). Below-appetite → proceed via `gh issue create`. Above-appetite → risk-reduce + re-score; if within → proceed; else → save draft to `## Queued Upstream Report` + queue `outstanding_questions` entry; orchestrator continues. Risk-reducing measures vocabulary is **open-ended LLM judgement** per ADR-024 2026-06-04 second-amendment leaf (a) — `wr-risk-scorer:external-comms` picks the remedy case-by-case. Voice-tone gate per ADR-028 may also delegate-and-retry on the proceed path. | ADR-024 2026-06-04 amendment (P270); ADR-024 2026-06-04 second-amendment (leaf a — open vocabulary); ADR-028 line 126 |
-| Dedup match — Step 4b (own re-run OR third-party `same-problem`) | Score the proposed comment body via `wr-risk-scorer:external-comms`. Below-appetite → proceed via `gh issue comment` (Step 5c). Above-appetite → risk-reduce + re-score (open-ended LLM judgement per leaf (a)); if within → proceed; else → save draft to `## Queued Upstream Report` + queue `outstanding_questions` entry; orchestrator continues. **The 2026-04-25 (P070) "interim static heuristic in force until that subagent ships" deferral is LIFTED** — the subagent (`packages/risk-scorer/agents/external-comms.md`) has shipped. | ADR-024 2026-06-04 amendment (P270); ADR-024 2026-04-25 amendment (P070); ADR-024 2026-06-04 second-amendment (leaf a) |
+| Dedup match — Step 4b (own re-run OR third-party `same-problem`) | Score the proposed comment body via `wr-risk-scorer:external-comms`. Below-appetite → comment on the matching issue or pull request (Step 5c). Above-appetite → risk-reduce + re-score (open-ended LLM judgement per leaf (a)); if within → proceed; else → save draft to `## Queued Upstream Report` + queue `outstanding_questions` entry; orchestrator continues. | ADR-024 2026-06-04 amendment (P270); ADR-024 2026-04-25 amendment (P070); ADR-024 2026-06-04 second-amendment (leaf a) |
 | Security path with declared channel (Step 6, GitHub Advisories — upstream has `SECURITY.md`) | Per ADR-024 2026-06-04 second-amendment leaf (b) — ratified: if upstream has `SECURITY.md` AND below-appetite → **file** via the SECURITY.md-declared channel. Above-appetite → risk-reduce + re-score (open-ended LLM judgement per leaf (a)); if within → proceed; else → save draft + queue; orchestrator continues. | ADR-024 2026-06-04 amendment (P270); ADR-024 2026-06-04 second-amendment (leaf b); ADR-024 Decision Outcome step 6 |
 | Security path with `security@` / other / missing-SECURITY.md (Step 6) | Per ADR-024 2026-06-04 second-amendment leaf (b) — ratified: when upstream has NO `SECURITY.md` but another disclosure channel exists, score drafted prose via `wr-risk-scorer:external-comms` considering impact to (i) our repository, (ii) our reputation, (iii) the party we are reporting to. Below-appetite → save drafted report to `## Queued Upstream Report` + queue `outstanding_questions` entry naming the channel the user must follow on return (the no-infra-for-email constraint still holds — the channel-action remains user-side, but the queue surface replaces the loop-stopping halt). Above-appetite → risk-reduce + re-score (open-ended LLM judgement per leaf (a)) then queue per the same shape. Orchestrator continues. The pre-2026-06-04 "AFK orchestrators must never auto-report a security-classified ticket" rule is **superseded** by the external-comms-gated per-classification branching. | ADR-024 2026-06-04 amendment (P270); ADR-024 2026-06-04 second-amendment (leaf b); ADR-024 Consequences lines 116, 123 (superseded) |
+| **Pull-request path (Step 5b)** | **Degrade to the issue branch.** No unattended session opens a pull request against a repository we do not own. File the issue per the Public-issue-path row above, and append the drafted pull request (body + the change it would have made) to `## Queued Upstream Report` for the interactive return. **Also surface it in the orchestrator's progress summary** — a returning developer must see "a pull request was drafted and queued" without opening the ticket. The external-comms gate reads prose; it cannot authorise pushing code into a third party's repository under our name, and that is a judgement call an unattended loop does not get to make. | ADR-117 (AFK degrade); JTBD-006 (no unattended judgement calls; visible on return) |
 | Above-appetite commit (Step 8) | Skip the commit, report uncommitted state. | ADR-013 Rule 6 |
 
 ## References
@@ -521,7 +691,9 @@ Five distinct AFK branches; **per the ADR-024 2026-06-04 (P270) amendment, ALL p
 - [ADR-033](../../../docs/decisions/033-report-upstream-classifier-problem-first.proposed.md) — partially supersedes ADR-024 Decision Outcome Steps 3 + 5; governs the problem-first classifier and problem-shaped structured default body.
 - [P070](../../../docs/problems/) — driver ticket for the Step 4b dedup check + Step 5c comment path; carries the 2026-04-21 Direction decision (gh search + inline LLM, no subagent dispatch) and the AFK static-heuristic interim behaviour.
 - [ADR-027](../../../docs/decisions/027-governance-skill-auto-delegation.proposed.md) — Step-0 deferral rationale (held for reassessment).
-- [ADR-028](../../../docs/decisions/028-voice-tone-gate-external-comms.proposed.md) — voice-tone gate on `gh issue create` and `gh api .../security-advisories`.
+- [ADR-117](../../../docs/decisions/117-prefer-an-upstream-pull-request-over-an-issue.proposed.md) — prefer an upstream pull request over an issue when the upstream accepts pull requests. Adds Step 4c (artefact choice) and Step 5b (pull-request path), extends Step 4b.2's dedup search to pull requests, branches Step 5c's comment call, and widens Step 7's disclosure-path enumeration without editing ADR-024 or ADR-033.
+- [P497](../../../docs/problems/open/497-upstream-pull-request-diff-is-unscored.md) — the pull-request **diff** is unscored. The prose is gated; nothing reads the diff against an upstream's policy. Named by ADR-117 and deliberately left open.
+- [ADR-028](../../../docs/decisions/028-voice-tone-gate-external-comms.proposed.md) — voice-tone gate on `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment` and `gh api .../security-advisories`.
 - [ADR-013](../../../docs/decisions/013-structured-user-interaction-for-governance-decisions.proposed.md) — interaction policy; Rule 1 governs Step 6 missing-SECURITY.md `AskUserQuestion`; Rule 6 governs the commit-gate AFK branch.
 - [ADR-014](../../../docs/decisions/014-governance-skills-commit-their-own-work.proposed.md) — work → score → commit ordering.
 - [ADR-015](../../../docs/decisions/015-on-demand-assessment-skills.proposed.md) — fallback path for `wr-risk-scorer:assess-release`.

--- a/packages/itil/skills/report-upstream/eval/grade-llm-rubric.sh
+++ b/packages/itil/skills/report-upstream/eval/grade-llm-rubric.sh
@@ -39,7 +39,15 @@ Set "pass" true only if the output satisfies the rubric. Be literal about
 negation: an output that says a thing does NOT happen SATISFIES a rubric
 requiring that the thing must not happen.'
 
-raw="$(claude -p --append-system-prompt "$GRADER_SYSTEM" "$@")"
+if [[ "${WR_EVAL_RUNTIME:-claude}" == "codex" ]]; then
+  raw="$(codex exec --ephemeral --ignore-user-config \
+    -c 'approval_policy="never"' --sandbox read-only \
+    "${GRADER_SYSTEM}
+
+${1:-}" </dev/null 2>/dev/null)"
+else
+  raw="$(claude -p --append-system-prompt "$GRADER_SYSTEM" "${1:-}")"
+fi
 
 # Defensive extraction: emit the first balanced {...} JSON object found in
 # the response, stripping any code fences or surrounding prose. If no brace

--- a/packages/itil/skills/report-upstream/eval/promptfooconfig.yaml
+++ b/packages/itil/skills/report-upstream/eval/promptfooconfig.yaml
@@ -63,12 +63,140 @@ providers:
 defaultTest:
   options:
     provider:
-      id: 'exec:bash ./grade-llm-rubric.sh'
+        id: 'exec:bash ./grade-llm-rubric.sh'
 
 prompts:
   - '{{prompt}}'
 
 tests:
+  - description: ADR-117 — the predicate is upstream acceptance, NOT our write access
+    vars:
+      prompt: |
+        I am executing /wr-itil:report-upstream for a non-security local
+        problem ticket P420 against https://github.com/some-vendor/some-lib,
+        a third-party dependency. We have NO write access to it — we are not
+        maintainers and never will be. The repository is active, not archived,
+        and ships a CONTRIBUTING.md. We have a small, defensible fix in hand.
+
+        Per ADR-117, does the skill prefer a pull request or an issue here?
+        State the predicate it applies and name the gh command it runs.
+    assert:
+      # Tier A — must open a pull request despite having no write access.
+      - type: icontains
+        value: 'gh pr create'
+      # Tier B — the predicate is the load-bearing part.
+      - type: llm-rubric
+        value: |
+          The response prefers a PULL REQUEST, and states that the predicate is
+          whether the upstream ACCEPTS pull requests (contributions), NOT
+          whether we hold write access or ownership. PASS if it opens a pull
+          request and mentions forking, or otherwise makes clear that lacking
+          write access is no obstacle. FAIL if it files an issue because we
+          lack write access, or if it states or implies that write access /
+          ownership / maintainer status is the deciding test.
+
+  - description: ADR-117 — own rerun of a recorded pull request comments on the pull request
+    vars:
+      prompt: |
+        I am executing /wr-itil:report-upstream interactively for local ticket
+        P420. Its existing ## Reported Upstream section records URL
+        https://github.com/some-vendor/some-lib/pull/123 and disclosure path
+        `pull request`. Fresh evidence should be added to that existing report,
+        and the user selected "Comment on the existing upstream report".
+
+        Per ADR-117, name the exact gh comment command family the skill uses.
+        Does it use the issue-comment command at any point?
+    assert:
+      - type: icontains
+        value: 'gh pr comment'
+      - type: llm-rubric
+        value: |
+          The response carries the recorded pull-request artefact kind into
+          the comment path and uses gh pr comment for pull request 123. It must
+          explicitly avoid gh issue comment. FAIL if it loses the artefact kind,
+          treats the recorded URL as an issue, or proposes gh issue comment.
+
+  - description: ADR-117 — no defensible fix in hand falls back to an issue, silently
+    vars:
+      prompt: |
+        I am executing /wr-itil:report-upstream for a non-security local
+        problem ticket P420 against an active upstream that clearly accepts
+        pull requests. But the ticket records only a symptom and a rough
+        hypothesis — we have no fix we could responsibly write into a codebase
+        we do not know.
+
+        Per ADR-117, what outbound artefact does the skill produce? Name the
+        gh command, and say whether it asks the person who reported the
+        problem to write a patch.
+    assert:
+      # Tier A — falls back to the issue path.
+      - type: icontains
+        value: 'gh issue create'
+      # Tier B — the silence is as load-bearing as the fallback.
+      - type: llm-rubric
+        value: |
+          The response says the skill FILES AN ISSUE because there is no
+          defensible fix in hand, AND that it does NOT ask the reporter
+          whether to author a patch — the determination is made by the agent
+          silently. PASS if both hold. FAIL if it opens a pull request anyway,
+          or if it raises an AskUserQuestion / prompts / consults the reporter
+          about whether to write a patch, or if it says the reporter must
+          supply a fix.
+
+  - description: ADR-117 — under AFK the pull-request path degrades to the issue path
+    vars:
+      prompt: |
+        I am executing /wr-itil:report-upstream for a non-security local
+        problem ticket P420 against an upstream that accepts pull requests.
+        We have a good fix in hand. The orchestrator is in AFK mode and the
+        external-comms gate scored the drafted prose BELOW appetite.
+
+        Per ADR-117, does an unattended session open the pull request? What
+        does it do with the drafted pull request, and what does the returning
+        developer see?
+    assert:
+      # Tier A — the drafted PR is queued to the named section.
+      - type: icontains
+        value: 'Queued Upstream Report'
+      # Tier B — degrade + queue + visible on return.
+      - type: llm-rubric
+        value: |
+          The response says an unattended session does NOT open a pull request
+          against a repository we do not own; it degrades to the issue path,
+          and queues the drafted pull request to the local ticket's
+          ## Queued Upstream Report section for the interactive return. PASS if
+          the degrade and the queue are both described. Credit, but do not
+          require, a mention that it also surfaces in the AFK progress summary,
+          or that a prose-only gate cannot authorise pushing code into someone
+          else's repository. FAIL if an unattended session opens the pull
+          request, or if the drafted pull request is discarded.
+
+  - description: ADR-117 — a security-classified ticket never routes to a pull request
+    vars:
+      prompt: |
+        I am executing /wr-itil:report-upstream for local problem ticket P420
+        which IS security-classified (its title names an auth bypass). The
+        upstream is active, accepts pull requests, ships a CONTRIBUTING.md and
+        a SECURITY.md declaring GitHub Security Advisories. We have a fix in
+        hand.
+
+        Per ADR-117 and ADR-024, what path does the skill take? Does the
+        pull-request preference apply here?
+    assert:
+      # Tier A — routes to the private advisory path.
+      - type: regex
+        value: '[Ss]ecurity[- ][Aa]dvisor(y|ies)'
+      # Tier B — ordering is the point: security is checked before artefact choice.
+      - type: llm-rubric
+        value: |
+          The response routes the ticket to the PRIVATE security-advisory path
+          declared in the upstream's SECURITY.md, and makes clear that the
+          pull-request preference does not apply because the security check
+          happens first and wins. PASS if it takes the private path and does
+          not open a public pull request or a public issue. FAIL if it opens a
+          pull request, or a public issue, or treats the pull-request
+          preference as overriding the security routing.
+
   - description: AFK below-appetite public-issue path → files via gh issue create
     vars:
       prompt: |

--- a/packages/itil/skills/report-upstream/eval/run-skill-eval.sh
+++ b/packages/itil/skills/report-upstream/eval/run-skill-eval.sh
@@ -20,12 +20,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_MD="${SCRIPT_DIR}/../SKILL.md"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
 if [[ ! -f "$SKILL_MD" ]]; then
   echo "run-skill-eval.sh: SKILL.md not found at $SKILL_MD" >&2
   exit 2
 fi
 
-# Pass the promptfoo prompt through as the user message. claude -p prints to
-# stdout, which promptfoo captures as the response under assertion.
-exec claude -p --append-system-prompt "$(cat "$SKILL_MD")" "$@"
+# Pass the promptfoo prompt through as the user message. Both runtimes print
+# to stdout, which promptfoo captures as the response under assertion.
+if [[ "${WR_EVAL_RUNTIME:-claude}" == "codex" ]]; then
+  exec codex exec --ephemeral --ignore-user-config --cd "$REPO_ROOT" \
+    -c 'approval_policy="never"' --sandbox read-only \
+    "Read ${SKILL_MD} and answer the validation prompt using that skill contract.
+
+${1:-}" </dev/null 2>/dev/null
+fi
+
+exec claude -p --append-system-prompt "$(cat "$SKILL_MD")" "${1:-}"

--- a/packages/itil/skills/report-upstream/test/report-upstream-contract.bats
+++ b/packages/itil/skills/report-upstream/test/report-upstream-contract.bats
@@ -124,11 +124,9 @@ setup() {
 }
 
 @test "report-upstream: SKILL.md drops the 'interim static heuristic' deferral on the dedup branch (P070 lift-condition met per P270 amendment)" {
-  # The 2026-04-25 (P070) amendment named the dedup-AFK as an "interim static
-  # heuristic in force until wr-risk-scorer:external-comms ships". The agent
-  # has shipped; the 2026-06-04 (P270) amendment lifts the deferral. The
-  # AFK summary's dedup-path row must cite the LIFT, not the deferral.
-  run grep -iE 'interim static heuristic.*lifted|deferral.*lifted|LIFTED' "$SKILL_MD"
+  run grep -iE 'interim static heuristic|static heuristic.*awaiting' "$SKILL_MD"
+  [ "$status" -ne 0 ]
+  run grep -iE 'dedup match.*wr-risk-scorer:external-comms|wr-risk-scorer:external-comms.*dedup' "$SKILL_MD"
   [ "$status" -eq 0 ]
 }
 
@@ -229,7 +227,7 @@ setup() {
   [ "${#lines[@]}" -ge 2 ]
 }
 
-# ─── P070 dedup contract (Step 4b + Step 5c + AFK static heuristic) ────────────
+# ─── P070 dedup contract (Step 4b + Step 5c + AFK risk gate) ──────────────────
 #
 # P070 inserts a dedup check between security-path routing (Step 4) and the
 # outbound `gh` call (Steps 5 / 6). Two duplication windows close at the same
@@ -237,11 +235,7 @@ setup() {
 # and third-party search (different reporter filed similar). Step 5c adds a
 # comment-on-existing-issue path used when the dedup branch finds a match.
 #
-# Per architect verdict on P070: the maintainer-annoyance risk evaluator is
-# deferred until ADR-028 / P064's `wr-risk-scorer:external-comms` subagent
-# ships (ADR-028 line 117 anticipates third evaluators). The interim AFK
-# branch uses a static heuristic — no subagent dispatch — that defaults to
-# halt-and-save.
+# The shipped `wr-risk-scorer:external-comms` gate now governs AFK comments.
 
 @test "report-upstream: SKILL.md contains a Step 4b dedup check (P070)" {
   run grep -nE '^### 4b\.' "$SKILL_MD"
@@ -290,31 +284,25 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "report-upstream: SKILL.md AFK branch uses static heuristic, defers maintainer-annoyance evaluator (P070 interim per ADR-028 line 117)" {
-  # Architect verdict: maintainer-annoyance evaluator deferred. AFK branch
-  # uses a static heuristic and defaults to halt-and-save. The SKILL.md must
-  # name the deferral explicitly so future readers know why the static-heuristic
-  # path exists; once `wr-risk-scorer:external-comms` lands, this branch
-  # gets re-wired.
-  run grep -iE 'static heuristic|interim.*heuristic|heuristic.*interim' "$SKILL_MD"
+@test "report-upstream: SKILL.md AFK dedup branch uses the shipped external-comms gate" {
+  run grep -iE 'dedup match.*wr-risk-scorer:external-comms|wr-risk-scorer:external-comms.*dedup' "$SKILL_MD"
   [ "$status" -eq 0 ]
-  run grep -iE 'wr-risk-scorer:external-comms|external-comms.*evaluator' "$SKILL_MD"
-  [ "$status" -eq 0 ]
+  run grep -iE 'interim static heuristic|static heuristic.*awaiting' "$SKILL_MD"
+  [ "$status" -ne 0 ]
 }
 
-@test "report-upstream: SKILL.md AFK halt-and-save writes Drafted Upstream Report section (P070 + ADR-024 Consequences)" {
-  # AFK halt branch saves the drafted report to the local ticket's
-  # `## Drafted Upstream Report` section — same pattern as the security-path
-  # halt per ADR-024 Consequences (lines 116, 123).
-  run grep -F '## Drafted Upstream Report' "$SKILL_MD"
+@test "report-upstream: SKILL.md AFK above-appetite branch queues without halting" {
+  run grep -F '## Queued Upstream Report' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -iE 'queue an `outstanding_questions` entry.*do not halt' "$SKILL_MD"
   [ "$status" -eq 0 ]
 }
 
 @test "report-upstream: SKILL.md AFK behaviour summary table includes the dedup branch (P070)" {
   # The "AFK behaviour summary" table at the bottom of the skill must list
-  # the new dedup-halt branch alongside the existing public-issue / security
+  # the dedup branch alongside the existing public-issue / security
   # / above-appetite branches.
-  run grep -iE 'dedup.*halt|step 4b.*halt|halt.*dedup|halt-and-save.*dedup' "$SKILL_MD"
+  run grep -iE 'dedup match.*step 4b|step 4b.*dedup match' "$SKILL_MD"
   [ "$status" -eq 0 ]
 }
 
@@ -391,4 +379,88 @@ setup() {
   # template-slot remains, but the top-level section header should be gone).
   run grep -nE '^## Environment$' "$SKILL_MD"
   [ "$status" -ne 0 ]
+}
+
+# ─── ADR-117 upstream pull-request path ──────────────────────────────────────
+
+@test "report-upstream: discovery fetches repository and contribution metadata" {
+  run grep -F 'REPO_JSON=$(gh api "repos/${UPSTREAM_OWNER_REPO}")' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'CONTRIBUTING.md' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'PULL_REQUEST_TEMPLATE.md' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "report-upstream: dedup combines issues and pull requests with an artefact kind" {
+  run grep -F 'map(. + {kind: "issue"})' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'map(. + {kind: "pull-request"})' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'gh pr view "$n"' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "report-upstream: pull-request path uses an isolated checkout and pushed head" {
+  run grep -F 'UPSTREAM_CHECKOUT=$(mktemp -d)' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'git push --set-upstream fork "$BRANCH"' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F -- '--head "${GH_USER}:${BRANCH}"' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "report-upstream: pull-request checkout is a subshell and preserves distinct bodies" {
+  run grep -F 'PR_URL=$(' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'ISSUE_BODY="${FILLED_BODY}"' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F -- '--body "${PR_BODY}"' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "report-upstream: eval runner and grader execute Codex while preserving the Claude default" {
+  local runner="$(dirname "$BATS_TEST_FILENAME")/../eval/run-skill-eval.sh"
+  local grader="$(dirname "$BATS_TEST_FILENAME")/../eval/grade-llm-rubric.sh"
+  local fake_bin
+  fake_bin="$(mktemp -d)"
+  cat > "$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'codex %s\n' "$*" >> "$FAKE_LOG"
+printf '{"pass":true,"score":1,"reason":"fake"}\n'
+EOF
+  cat > "$fake_bin/claude" <<'EOF'
+#!/usr/bin/env bash
+printf 'claude %s\n' "$*" >> "$FAKE_LOG"
+printf 'claude-default\n'
+EOF
+  chmod +x "$fake_bin/codex" "$fake_bin/claude"
+
+  run env WR_EVAL_RUNTIME=codex FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$runner" "runner-sentinel"
+  [ "$status" -eq 0 ]
+  grep -F 'codex exec --ephemeral' "$fake_bin/log"
+  grep -F 'runner-sentinel' "$fake_bin/log"
+
+  run env WR_EVAL_RUNTIME=codex FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$grader" "grader-sentinel"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.pass == true'
+  grep -F 'grader-sentinel' "$fake_bin/log"
+
+  run env FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$runner" "claude-sentinel"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude-default" ]
+  grep -F 'claude -p' "$fake_bin/log"
+  rm -rf "$fake_bin"
+}
+
+@test "report-upstream: title and body are explicitly reviewed together" {
+  run grep -F 'combined title and body' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'hook extracts only the `--body` value' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "report-upstream: pull-request dedup comments retain their disclosure path" {
+  run grep -F 'commented-on-existing-pull-request' "$SKILL_MD"
+  [ "$status" -eq 0 ]
 }

--- a/packages/itil/skills/update-upstream/SKILL.md
+++ b/packages/itil/skills/update-upstream/SKILL.md
@@ -23,7 +23,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Skill, Agen
 
 # Update Upstream — Lifecycle-Update Skill
 
-Post a lifecycle-update comment to an upstream issue (or close it) when the local problem ticket transitions. Reads the local ticket's `## Reported Upstream` section, drafts a transition-specific update from the templates below, composes the draft through the external-comms risk gate (`wr-risk-scorer:external-comms`) and voice-tone gate (`wr-voice-tone:external-comms`), auto-posts via `gh issue comment` (or `gh issue close` on Verifying → Closed) when both gates pass within appetite, and queues an `outstanding_questions` entry when either gate scores above appetite.
+Post a lifecycle-update comment to an upstream issue or pull request when the local problem ticket transitions. Reads the local ticket's `## Reported Upstream` section, drafts a transition-specific update from the templates below, composes the draft through the external-comms risk gate (`wr-risk-scorer:external-comms`) and voice-tone gate (`wr-voice-tone:external-comms`), auto-posts via `gh issue comment` or `gh pr comment` when both gates pass within appetite, closes only issue targets on Verifying → Closed, and queues an `outstanding_questions` entry when either gate scores above appetite.
 
 This skill is the **reciprocal sibling** to [`/wr-itil:report-upstream`](../report-upstream/SKILL.md) — that skill files the initial upstream report; this skill keeps the upstream record in sync as the local ticket walks its lifecycle. The split is per [ADR-010](../../../docs/decisions/010-rename-wr-problem-to-wr-itil.proposed.md) amended Skill Granularity rule (one skill per distinct user intent) — initial-filing and lifecycle-update are distinct user intents with distinct autocomplete surfaces.
 
@@ -49,7 +49,7 @@ The single-ticket form is typically invoked from `/wr-itil:transition-problem` S
 - Determine the local ticket's current Status from the filename suffix.
 - Draft a transition-specific lifecycle-update comment per the templates below (Open→KE / KE→Verifying / Verifying→Closed).
 - Compose the drafted prose through `wr-risk-scorer:external-comms` + `wr-voice-tone:external-comms` gates.
-- Within appetite → post via `gh issue comment <n>`; on Verifying→Closed also run `gh issue close <n>`.
+- Within appetite → post via `gh issue comment <n>`, or `gh pr comment <n>` when the disclosure path records a pull request (ADR-117); on Verifying→Closed also run `gh issue close <n>` — **but never `gh pr close`** (see below).
 - Above appetite → AskUserQuestion (interactive) / queue `outstanding_questions` (AFK, per P352 queue-and-continue).
 - Back-write a `## Upstream Lifecycle Updates` log entry to the local ticket recording the transition, the matched URL, the posted comment URL, and the disclosure path.
 - **Historical catch-up migration (`--catchup`, P080 Phase 2)** — one-shot retroactive scan of the existing `.verifying.md` + `.closed.md` corpus; posts the lifecycle update each linked-upstream ticket should already carry. Idempotent — re-running is safe. See [§ Catchup migration mode](#catchup-migration-mode-phase-2).
@@ -269,6 +269,14 @@ gh issue close "${UPSTREAM_ISSUE_NUMBER}" \
 
 If the issue is already closed upstream (someone else closed it manually), `gh issue close` returns a benign error — capture the existing state and continue to Step 6 with `closed-already-upstream` recorded in the back-write disclosure path.
 
+#### Pull-request targets never get closed (ADR-117)
+
+When the `## Reported Upstream` disclosure path records a **pull request**, post the comment with `gh pr comment` and **stop there**. Do not run `gh pr close`, on this transition or any other.
+
+A merged pull request closes itself, so closing is redundant. An unmerged one is still work we authored and offered; closing it is a hostile act against our own contribution and withdraws it from the maintainer's queue without saying so. The local ticket reaching `.closed.md` means *we* consider the problem resolved locally — it does not mean the upstream has finished deciding.
+
+Record `posted-pr-comment` in the back-write disclosure path. On a pull-request target `posted-comment-and-closed` is unreachable by construction.
+
 ### 6. Back-write to local ticket
 
 Append a log entry to the local ticket's `## Upstream Lifecycle Updates` section (create the section if absent — never inserted mid-document; appended after all existing sections per the same discipline as `## Reported Upstream` in `/wr-itil:report-upstream` Step 7):
@@ -279,7 +287,7 @@ Append a log entry to the local ticket's `## Upstream Lifecycle Updates` section
 - **<YYYY-MM-DD>** — Open → Known Error
   - **Target URL**: <upstream-issue-url>
   - **Comment URL**: <posted-comment-url> (or "queued — see ## Queued Upstream Update" when above-appetite)
-  - **Disclosure path**: posted-comment | posted-comment-and-closed (Verifying → Closed) | queued-above-appetite | closed-already-upstream | skipped-out-of-band
+  - **Disclosure path**: posted-comment | posted-pr-comment (pull-request target, ADR-117 — never closed) | posted-comment-and-closed (Verifying → Closed, issue targets only) | queued-above-appetite | closed-already-upstream | skipped-out-of-band
   - **Gate verdict**: external-comms <band/score> + voice-tone <pass|fail>
 
 - **<YYYY-MM-DD>** — Known Error → Verification Pending
@@ -495,9 +503,9 @@ The append-only log (written by Step 6 on every post) is the source of truth —
 
 ### C3. Process each CATCHUP entry
 
-For each `CATCHUP` line, run the **existing per-ticket flow** (Steps 4–6) against that ticket ID:
+For each `CATCHUP` line, parse its `disclosure=` token and run the **existing per-ticket flow** (Steps 4–6) against that ticket ID. `disclosure=pull-request` selects `gh pr comment` and forbids any close command; `disclosure=issue` selects `gh issue comment` and permits `gh issue close` for Verifying → Closed:
 
-1. Draft the transition template (Step 4) for the entry's transition (`KE->Verifying` → Known Error → Verification Pending template; `Verifying->Closed` → Verification Pending → Closed template, which also runs `gh issue close`).
+1. Draft the transition template (Step 4) for the entry's transition (`KE->Verifying` → Known Error → Verification Pending template; `Verifying->Closed` → Verification Pending → Closed template). Only an issue disclosure also runs `gh issue close`; a pull-request disclosure never runs `gh pr close`.
 2. Compose through the external-comms + voice-tone gates (Step 5) — **identical** dual-gate composition as the per-ticket path. Above-appetite handling (Step 5c) is unchanged: silent risk-reduce + re-score, then queue to `## Queued Upstream Update` + `outstanding_questions` (category `deviation-approval`) per P352 if still above. Catchup does NOT bypass the gates.
 3. Post within appetite (Step 5b final) and back-write the `## Upstream Lifecycle Updates` log (Step 6).
 

--- a/packages/itil/skills/update-upstream/eval/grade-llm-rubric.sh
+++ b/packages/itil/skills/update-upstream/eval/grade-llm-rubric.sh
@@ -37,7 +37,15 @@ Set "pass" true only if the output satisfies the rubric. Be literal about
 negation: an output that says a thing does NOT happen SATISFIES a rubric
 requiring that the thing must not happen.'
 
-raw="$(claude -p --append-system-prompt "$GRADER_SYSTEM" "$@")"
+if [[ "${WR_EVAL_RUNTIME:-claude}" == "codex" ]]; then
+  raw="$(codex exec --ephemeral --ignore-user-config \
+    -c 'approval_policy="never"' --sandbox read-only \
+    "${GRADER_SYSTEM}
+
+${1:-}" </dev/null 2>/dev/null)"
+else
+  raw="$(claude -p --append-system-prompt "$GRADER_SYSTEM" "${1:-}")"
+fi
 
 # Defensive extraction: emit the first balanced {...} JSON object found in
 # the response, stripping any code fences or surrounding prose. If no brace

--- a/packages/itil/skills/update-upstream/eval/promptfooconfig.yaml
+++ b/packages/itil/skills/update-upstream/eval/promptfooconfig.yaml
@@ -67,7 +67,7 @@ providers:
 defaultTest:
   options:
     provider:
-      id: 'exec:bash ./grade-llm-rubric.sh'
+        id: 'exec:bash ./grade-llm-rubric.sh'
 
 prompts:
   - '{{prompt}}'
@@ -144,6 +144,37 @@ tests:
           halting the loop. FAIL if it says the orchestrator HALTS / STOPS /
           BLOCKS the loop on the above-appetite branch. An output that says
           it does NOT halt (a negation) PASSES.
+
+  - description: ADR-117 — Verifying→Closed on a PULL-REQUEST target comments but never closes
+    vars:
+      prompt: |
+        I am executing /wr-itil:update-upstream for local problem ticket P421
+        which just transitioned from Verification Pending to Closed. The local
+        ticket's ## Reported Upstream section points at
+        https://github.com/anthropics/claude-code/pull/1234 and records
+        `- **Disclosure path**: pull request`. Both gates (external-comms +
+        voice-tone) returned PASS.
+
+        Per ADR-117, what does the skill do on this transition? Name the gh
+        command it runs, say whether it closes the upstream artefact, and
+        explain why.
+    assert:
+      # Tier A — comments on the pull request, not the issue.
+      - type: icontains
+        value: 'gh pr comment'
+      # The never-close clause is NEGATIVE, so it is Tier-B only: the
+      # correct answer says "No `gh pr close`", and a not-icontains fires
+      # against the forbidden substring sitting inside that negation.
+      - type: llm-rubric
+        value: |
+          The response says the skill posts a comment via gh pr comment and
+          does NOT close the pull request. PASS if it both names gh pr comment
+          and states that the pull request is left open, for any of these
+          reasons: a merged pull request closes itself; closing an unmerged one
+          withdraws work we authored; the local ticket being closed reflects our
+          local judgement, not the upstream's decision. FAIL if it runs
+          gh pr close, or gh issue close against the pull request, or describes
+          closing the upstream artefact as required on this transition.
 
   - description: Verifying→Closed transition → posts comment AND runs gh issue close
     vars:

--- a/packages/itil/skills/update-upstream/eval/run-skill-eval.sh
+++ b/packages/itil/skills/update-upstream/eval/run-skill-eval.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_MD="${SCRIPT_DIR}/../SKILL.md"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
 if [[ ! -f "$SKILL_MD" ]]; then
   echo "run-skill-eval.sh: SKILL.md not found at $SKILL_MD" >&2
@@ -26,4 +27,12 @@ fi
 
 # Pass the promptfoo prompt through as the user message. claude -p prints to
 # stdout, which promptfoo captures as the response under assertion.
-exec claude -p --append-system-prompt "$(cat "$SKILL_MD")" "$@"
+if [[ "${WR_EVAL_RUNTIME:-claude}" == "codex" ]]; then
+  exec codex exec --ephemeral --ignore-user-config --cd "$REPO_ROOT" \
+    -c 'approval_policy="never"' --sandbox read-only \
+    "Read ${SKILL_MD} and answer the validation prompt using that skill contract.
+
+${1:-}" </dev/null 2>/dev/null
+fi
+
+exec claude -p --append-system-prompt "$(cat "$SKILL_MD")" "${1:-}"

--- a/packages/itil/skills/update-upstream/test/update-upstream-contract.bats
+++ b/packages/itil/skills/update-upstream/test/update-upstream-contract.bats
@@ -86,6 +86,40 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "update-upstream: eval runner and grader execute Codex while preserving the Claude default" {
+  local runner="$(dirname "$BATS_TEST_FILENAME")/../eval/run-skill-eval.sh"
+  local grader="$(dirname "$BATS_TEST_FILENAME")/../eval/grade-llm-rubric.sh"
+  local fake_bin
+  fake_bin="$(mktemp -d)"
+  cat > "$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'codex %s\n' "$*" >> "$FAKE_LOG"
+printf '{"pass":true,"score":1,"reason":"fake"}\n'
+EOF
+  cat > "$fake_bin/claude" <<'EOF'
+#!/usr/bin/env bash
+printf 'claude %s\n' "$*" >> "$FAKE_LOG"
+printf 'claude-default\n'
+EOF
+  chmod +x "$fake_bin/codex" "$fake_bin/claude"
+
+  run env WR_EVAL_RUNTIME=codex FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$runner" "runner-sentinel"
+  [ "$status" -eq 0 ]
+  grep -F 'codex exec --ephemeral' "$fake_bin/log"
+  grep -F 'runner-sentinel' "$fake_bin/log"
+
+  run env WR_EVAL_RUNTIME=codex FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$grader" "grader-sentinel"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.pass == true'
+  grep -F 'grader-sentinel' "$fake_bin/log"
+
+  run env FAKE_LOG="$fake_bin/log" PATH="$fake_bin:$PATH" "$runner" "claude-sentinel"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude-default" ]
+  grep -F 'claude -p' "$fake_bin/log"
+  rm -rf "$fake_bin"
+}
+
 @test "update-upstream: SKILL.md composes through voice-tone gate (P080 user direction (b) + ADR-028)" {
   # User direction (b) — voice-tone gated. The gate is wr-voice-tone:agent
   # firing on gh issue comment / gh issue close per ADR-028.
@@ -371,5 +405,14 @@ setup() {
   [ -f "$GRADER" ]
   [ -x "$GRADER" ]
   run grep -F 'llm-rubric' "$EVAL_CONFIG"
+  [ "$status" -eq 0 ]
+}
+
+@test "update-upstream: catchup honours the disclosure discriminator" {
+  run grep -F 'parse its `disclosure=` token' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F '`disclosure=pull-request` selects `gh pr comment`' "$SKILL_MD"
+  [ "$status" -eq 0 ]
+  run grep -F 'never runs `gh pr close`' "$SKILL_MD"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

Replaces #417 with a clean port on current `main`. The stale branch collided with the current ADR-102 and P477 and no longer merged cleanly; this version preserves the ratified decision as ADR-117 and tracks the remaining diff-review gap as P497 without changing either occupied record.

`/wr-itil:report-upstream` now prefers a pull request when the upstream accepts contributions and a defensible fix is available. Contribution acceptance, not write access, is the predicate: the normal third-party path is an isolated checkout, a fork, a pushed branch, and `gh pr create` with an explicit head and base.

The issue path remains the fallback when the upstream does not accept contributions, the fix needs a maintainer-owned design decision, the report is security-classified, or no defensible fix is available within three attempts or 20 minutes. The skill drafts the issue first, so a failed pull-request attempt still files the report. AFK sessions never open third-party pull requests.

## Integration changes

- Discovery now fetches repository metadata, contribution guidance, and pull-request templates before choosing the route.
- Deduplication searches both issues and pull requests, carries the artifact kind, and comments with the matching `gh` command.
- Pull-request titles and bodies are explicitly reviewed together by the external-communications evaluators; the command hook independently enforces the body review.
- Response polling uses `gh pr view`, counts reviews as responses, and reads inline review comments through the GitHub API without treating label-only PR updates as maintainer responses.
- Catch-up and lifecycle updates preserve the issue/pull-request discriminator, use `gh pr comment` for pull requests, and never close them.
- Legacy tickets with no disclosure path remain issue-shaped and require no extra probe.

The outgoing diff is still not scored against a third party's contribution policy. The skill displays it before creation, requires the upstream checkout and checks to be named, and records the gap in P497.

## Validation

- Focused ITIL BATS: 104 passed, 0 failed.
- Codex Promptfoo: all six ADR-117 behavior cases passed, including pull-request creation, fallbacks, and pull-request comment reruns.
- Decision compendium and problem README reconciliation: clean.
- Architecture review: PASS. Pipeline risk: commit=4, push=4, release=4.
- The current full suite was interrupted after 1,053 of 4,155 tests passed with no failures; CI remains authoritative. Claude Promptfoo was unavailable because the account had reached its weekly subscription limit, so no Claude Promptfoo pass is claimed.

## History

ADR-117 retains the human confirmation recorded for the same decision on 2026-08-08. The renumbering is collision-only; the implementation does not amend ADR-024, ADR-033, ADR-102, P290, or P477.
