### PR TITLE
fix(risk-scorer): preserve checkout-bound markers

### DIFF
--- a/.changeset/risk-scorer-preserve-checkout-marker.md
+++ b/.changeset/risk-scorer-preserve-checkout-marker.md
@@ -1,0 +1,5 @@
+---
+"@windyroad/risk-scorer": patch
+---
+
+Preserve checkout-bound reducing markers when Codex omits a nested command workdir, and provide an explicit checkout retry command instead of forcing another score.

--- a/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
+++ b/docs/problems/open/477-codex-interrupt-agent-completion-bypasses-risk-marker-bridge.md
@@ -24,6 +24,8 @@ The bridge assumed every native collaboration spawn and close would be observabl
 
 The sanitized receipt path shipped, but a live 2026-08-14 desktop replay exposed a second defect: a trusted and enabled `SubagentStop` completed with the expected pipeline role and reducing verdict, yet no pending receipt was written. The bridge returned silently for every rejected payload or derived-state condition, leaving no way to distinguish an event that did not fire from a payload-shape mismatch, identity rejection, state-hash failure, or receipt collision. This observability gap is part of P477 because it prevents the repaired handoff from being verified or diagnosed without reading private transcripts.
 
+A 2026-08-16 isolated-checkout replay exposed a third failure in the same handoff. Codex executed `git commit` in the assessed checkout, but the compatibility payload exposed only the parent task checkout. The gate correctly rejected the checkout mismatch, then incorrectly deleted the valid reducing marker. Every retry therefore required another score and repeated the same deletion. The hook cannot recover an omitted path from the opaque checkout identity, so it must preserve the marker and prescribe an explicit leading `cd` rather than consume valid evidence.
+
 ## Fix and Verification
 
 - On a risk-scorer `SubagentStop` without spawn state, publish a short-lived sanitized receipt bound to the exact physical checkout and pipeline state hash.
@@ -31,6 +33,7 @@ The sanitized receipt path shipped, but a live 2026-08-14 desktop replay exposed
 - Reproduce distinct child/parent sessions with no spawn-state file and assert scores, state hash, and opaque checkout identity persist only for the assessed checkout.
 - Reject malformed output, invalid roots, checkout drift, expired receipts, and duplicate completion without persisting an absolute path.
 - Persist one atomically replaced, mode-0600 diagnostic containing only timestamp, outcome/rejection code, normalized event name, and field presence/types. Never persist response text, working directories, session IDs, agent IDs, or absolute paths.
+- When a command arrives from a different checkout than a valid checkout-bound reducing marker, deny without consuming the marker and direct Codex to retry the same command as `cd /absolute/assessed/checkout && ...`. Continue consuming markers on expiry or assessed-state drift.
 - Release and supported-install the patch before the downstream consumer retries its normal gate.
 
 No new hook or ADR is required: this restores the intended completed-agent compatibility path using the already-enabled `SubagentStop`, `PreToolUse:Bash`, and `UserPromptSubmit` events without changing the scoring or delivery contract.
@@ -44,7 +47,7 @@ No new hook or ADR is required: this restores the intended completed-agent compa
 
 | RFC | Status | Title |
 |-----|--------|-------|
-| RFC-067 | proposed | Make Codex SubagentStop receipt rejection diagnosable |
+| RFC-067 | proposed | Make Codex risk-receipt failures diagnosable and recoverable |
 
 ## Stories
 

--- a/docs/rfcs/RFC-067-codex-risk-receipt-failures-diagnosable-and-recoverable.proposed.md
+++ b/docs/rfcs/RFC-067-codex-risk-receipt-failures-diagnosable-and-recoverable.proposed.md
@@ -1,0 +1,41 @@
+---
+status: proposed
+rfc-id: codex-risk-receipt-failures-diagnosable-and-recoverable
+reported: 2026-08-14
+human-oversight: unconfirmed
+decision-makers: [Tom Howard]
+problems: [P477]
+adrs: [ADR-029, ADR-045, ADR-083]
+jtbd: [JTBD-001, JTBD-002]
+stories: [STORY-061]
+---
+
+# RFC-067: Make Codex risk-receipt failures diagnosable and recoverable
+
+**Status**: proposed
+**Reported**: 2026-08-14
+**Problems**: P477
+**JTBD**: JTBD-001, JTBD-002
+
+## Summary
+
+Keep checkout binding fail-closed while making Codex receipt failures actionable. Record privacy-safe `SubagentStop` rejection reasons. When Codex omits an isolated command's workdir, preserve a valid marker bound to that checkout and direct the agent to retry the same command with an explicit leading `cd`; do not force a rescore that will repeat the same failure.
+
+## Scope
+
+- Retain opaque physical-checkout identity and pipeline-state-hash validation.
+- Consume reducing markers on expiry or assessed-state drift, not on a different checkout's event.
+- Persist no working directory, response text, session ID, or agent ID in diagnostics or markers.
+- Add focused behavioral coverage for receipt diagnostics and isolated-checkout command recovery.
+- Ship the repair as a patch release of `@windyroad/risk-scorer`.
+
+## Stories
+
+| ID | Title | Status |
+|----|-------|--------|
+| STORY-061 | See why a SubagentStop risk receipt was not written | accepted |
+
+## Related
+
+- P477
+- ADR-029, ADR-045, ADR-083

--- a/packages/risk-scorer/hooks/git-push-gate.sh
+++ b/packages/risk-scorer/hooks/git-push-gate.sh
@@ -52,7 +52,11 @@ if echo "$COMMAND" | grep -qE '(^|;|&&|\|\|)\s*npm run push:watch(\s|$)'; then
             MARK_TIME=$(_mtime "${RDIR}/reducing-push")
             AGE=$(( NOW - MARK_TIME ))
             TTL_SECONDS="${RISK_TTL:-3600}"
-            if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ] && _checkout_matches "${RDIR}/checkout-id"; then
+            if [ "$AGE" -lt "$TTL_SECONDS" ] && ! _checkout_matches "${RDIR}/checkout-id"; then
+                risk_gate_deny "Push blocked: this event resolved to a different Git checkout than the valid risk assessment. Retry the same command with an explicit leading \`cd /absolute/path/to/the/assessed-checkout && npm run push:watch\`; the marker was preserved, so do not rescore unless that checkout changed."
+                exit 0
+            fi
+            if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ]; then
                 STORED_HASH=$(cat "${RDIR}/state-hash")
                 CURRENT_HASH=$("$SCRIPT_DIR/lib/pipeline-state.sh" --hash-inputs 2>/dev/null | _hashcmd | cut -d' ' -f1)
                 if [ "$STORED_HASH" = "$CURRENT_HASH" ]; then
@@ -129,7 +133,11 @@ if echo "$COMMAND" | grep -qE '(^|;|&&|\|\|)\s*npm run release:watch(\s|$)'; the
             MARK_TIME=$(_mtime "${RDIR}/reducing-release")
             AGE=$(( NOW - MARK_TIME ))
             TTL_SECONDS="${RISK_TTL:-3600}"
-            if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ] && _checkout_matches "${RDIR}/checkout-id"; then
+            if [ "$AGE" -lt "$TTL_SECONDS" ] && ! _checkout_matches "${RDIR}/checkout-id"; then
+                risk_gate_deny "Release blocked: this event resolved to a different Git checkout than the valid risk assessment. Retry the same command with an explicit leading \`cd /absolute/path/to/the/assessed-checkout && npm run release:watch\`; the marker was preserved, so do not rescore unless that checkout changed."
+                exit 0
+            fi
+            if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ]; then
                 STORED_HASH=$(cat "${RDIR}/state-hash")
                 CURRENT_HASH=$("$SCRIPT_DIR/lib/pipeline-state.sh" --hash-inputs 2>/dev/null | _hashcmd | cut -d' ' -f1)
                 if [ "$STORED_HASH" = "$CURRENT_HASH" ]; then

--- a/packages/risk-scorer/hooks/risk-score-commit-gate.sh
+++ b/packages/risk-scorer/hooks/risk-score-commit-gate.sh
@@ -96,7 +96,11 @@ if [ -f "${RDIR}/reducing-commit" ]; then
     MARK_TIME=$(_mtime "${RDIR}/reducing-commit")
     AGE=$(( NOW - MARK_TIME ))
     TTL_SECONDS="${RISK_TTL:-3600}"
-    if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ] && _checkout_matches "${RDIR}/checkout-id"; then
+    if [ "$AGE" -lt "$TTL_SECONDS" ] && ! _checkout_matches "${RDIR}/checkout-id"; then
+        risk_gate_deny "Commit blocked: this event resolved to a different Git checkout than the valid risk assessment. Retry the same command with an explicit leading \`cd /absolute/path/to/the/assessed-checkout && git commit ...\`; the marker was preserved, so do not rescore unless that checkout changed."
+        exit 0
+    fi
+    if [ "$AGE" -lt "$TTL_SECONDS" ] && [ -f "${RDIR}/state-hash" ]; then
         STORED_HASH=$(cat "${RDIR}/state-hash")
         CURRENT_HASH=$("$SCRIPT_DIR/lib/pipeline-state.sh" --hash-inputs 2>/dev/null | _hashcmd | cut -d' ' -f1)
         if [ "$STORED_HASH" = "$CURRENT_HASH" ]; then

--- a/packages/risk-scorer/hooks/test/reducing-marker-persistence.bats
+++ b/packages/risk-scorer/hooks/test/reducing-marker-persistence.bats
@@ -145,15 +145,23 @@ print(json.dumps({
   [ -f "$RDIR/reducing-commit" ]
 }
 
-@test "identical-tree checkout cannot reuse reducing-commit marker" {
+@test "Codex parent cwd mismatch preserves the marker and explicit cd recovers" {
+  cd "$OTHER_REPO"
+  _checkout_id > "$RDIR/checkout-id"
   HASH=$(_current_hash)
   echo "$HASH" > "$RDIR/state-hash"
   touch "$RDIR/reducing-commit"
 
-  cd "$OTHER_REPO"
-  run invoke_commit_gate 'git commit -m "x"'
+  cd "$TMP_REPO"
+  HOOK_CWD="$TMP_REPO" run invoke_commit_gate 'git commit -m "x"'
   [[ "$output" == *"permissionDecision"* ]]
-  [ ! -f "$RDIR/reducing-commit" ]
+  [[ "$output" == *"explicit leading"* ]]
+  [ -f "$RDIR/reducing-commit" ]
+
+  HOOK_CWD="$TMP_REPO" run invoke_commit_gate "cd '$OTHER_REPO' && git commit -m x"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"deny"* ]]
+  [ -f "$RDIR/reducing-commit" ]
 }
 
 @test "commit gate validates from the command cwd, not the hook process cwd" {


### PR DESCRIPTION
## Summary
- preserve valid checkout-bound reducing markers when Codex resolves a nested command to the parent checkout
- keep checkout mismatches fail-closed and provide an explicit leading-cd recovery command without forcing a rescore
- trace the repair through P477, RFC-067, and STORY-061

## Tests
- `bats packages/risk-scorer/hooks/test/` (233 passing)
- `npm run check:agent-instructions`
- `npm run check:plugin-manifests`
- `npm run check:codex-plugin-manifests`
- `npm run check:codex-agents`
