### PR TITLE
fix(risk-scorer): normalize Codex agent targets

### DIFF
--- a/.changeset/normalize-codex-risk-targets.md
+++ b/.changeset/normalize-codex-risk-targets.md
@@ -1,0 +1,5 @@
+---
+"@windyroad/risk-scorer": patch
+---
+
+Recognize relative Codex completion targets for canonically named risk agents.

--- a/packages/risk-scorer/hooks/codex-agent-completion.mjs
+++ b/packages/risk-scorer/hooks/codex-agent-completion.mjs
@@ -65,7 +65,8 @@ function diagnoseSubagentStop(input, outcome, reason) {
 }
 
 function statePath(input, target, suffix = "") {
-  return join(riskDir(input.session_id), `codex-agent-${Buffer.from(target).toString("base64url")}${suffix}`);
+  const normalized = target.startsWith("/root/") ? target.slice("/root/".length) : target;
+  return join(riskDir(input.session_id), `codex-agent-${Buffer.from(normalized).toString("base64url")}${suffix}`);
 }
 
 function clearTarget(input, target) {

--- a/packages/risk-scorer/hooks/test/codex-agent-completion.bats
+++ b/packages/risk-scorer/hooks/test/codex-agent-completion.bats
@@ -70,7 +70,7 @@ current_pipeline_close_input() {
 
 direct_pipeline_interrupt_input() {
   printf '{"session_id":"%s","cwd":"%s","tool_name":"interrupt_agent","tool_input":{"target":"%s"},"tool_response":{"previous_status":{"completed":"RISK_SCORES: commit=4 push=4 release=4\\nRISK_CWD: %s"}}}' \
-    "$SESSION" "$OTHER_REPO" "$TARGET" "$PIPELINE_REPO"
+    "$SESSION" "$OTHER_REPO" "${TARGET#/root/}" "$PIPELINE_REPO"
 }
 
 current_empty_wait_input() {


### PR DESCRIPTION
## Summary
- normalize canonical `/root/name` and relative `name` Codex completion targets at the shared state-key boundary
- retain checkout-bound receipt binding, atomic dedupe, and silent completion behavior
- adapt the existing direct-interrupt regression

## Verification
- `npx bats packages/risk-scorer/hooks/test/codex-agent-completion.bats` (23 passed)
- `npx bats --recursive packages/risk-scorer/hooks/test` (233 passed)
- `npx bats packages/shared/test/risk-scorer-codex-plugin.bats` (9 passed)
- Codex/plugin manifest, agent-instruction, syntax, and diff checks passed
- final architecture review: PASS; no new ADR
- pipeline risk: commit=4, push=4, release=4