### PR TITLE
fix(itil): relevance evaluator treats a citation as proof a fix shipped

### DIFF
--- a/.changeset/elided-path-not-evidence-of-deletion.md
+++ b/.changeset/elided-path-not-evidence-of-deletion.md
@@ -1,0 +1,15 @@
+---
+"@windyroad/itil": patch
+---
+
+Relevance evaluator: an abbreviated path in ticket prose is no longer read as a deleted file
+
+The path-extraction regex in `evaluate-relevance.sh` admits `.` and `/`, so an
+elided reference written inside backticks — `packages/itil/hooks/lib/.../detectors.sh`,
+or `docs/decisions/044-....md` — extracted as though it were a real path, was
+found absent, and counted as evidence that the file had been deleted. A ticket
+could therefore be judged fixed because its prose had been shortened.
+
+Candidates carrying an ellipsis are now skipped. (The Unicode form never
+matched the extractor in the first place; a regression case keeps it that way.) Genuinely absent paths are
+unaffected, and a ticket that cites both still reports only the real one.

--- a/.changeset/shape-two-corroborating-only.md
+++ b/.changeset/shape-two-corroborating-only.md
@@ -1,0 +1,20 @@
+---
+"@windyroad/itil": patch
+---
+
+Relevance evaluator: `ADR-shipped-confirmed` no longer closes a ticket on its own
+
+`evaluate-relevance.sh` treated a decision record carrying
+`human-oversight: confirmed` as evidence that a ticket's fix had shipped. That
+marker records that a human ratified a decision, not that anything was built or
+released. Because most decision records carry it and most tickets cite one, the
+shape matched most of the backlog and carried almost no signal — and
+`/wr-itil:review-problems` Step 4.6 closes clean candidates silently when
+running unattended.
+
+The shape is now corroborating-only. It is still detected and still cited, and
+its behaviour alongside any other evidence shape is unchanged. When it is the
+only shape that matched, the verdict is demoted to
+`CLOSE-CANDIDATE-WITH-CAVEAT` under the tag `ratification-is-not-delivery`,
+which the same step already routes to the maintainer's confirmation surface
+instead of closing.

--- a/packages/itil/scripts/evaluate-relevance.sh
+++ b/packages/itil/scripts/evaluate-relevance.sh
@@ -6,6 +6,7 @@
 # evidence shapes per ADR-079 (Phase 1 + Phase 2):
 #
 #   Shape 1 — file-no-longer-exists  (Phase 1, original)
+#             Elided prose references (`.../`) are not paths.
 #   Shape 2 — ADR-shipped with `human-oversight: confirmed`  (Phase 2)
 #             CORROBORATING-ONLY — never a clean CLOSE on its own.
 #   Shape 3 — named-skill-or-feature-exists  (Phase 2)
@@ -245,9 +246,19 @@ record_shape() {
 # candidate. Detects state-suffix / sibling-file / rename to avoid Phase 1
 # false-positives (P180/P244/P251); on detection routes to KEEP-WITH-NOTE.
 
+# The character class admits `.` and `/`, so an ELIDED reference in prose
+# (`packages/itil/hooks/lib/.../detectors.sh`, `docs/decisions/044-....md`)
+# extracts as a path, is found absent, and is counted as evidence the file
+# was deleted — concluding a ticket was fixed because its prose was
+# abbreviated. An abbreviation was never a path assertion, so drop any
+# candidate carrying an ASCII ellipsis. The Unicode `…` form needs no
+# filter — it is outside the character class above, so it never extracts
+# as a path in the first place (pinned by a bats case regardless). Fourth
+# member of the Phase 1 false-positive class alongside P180/P244/P251.
 candidates=$(grep -oE '(packages|docs|\.changeset|src|test|scripts)/[A-Za-z0-9._/-]+\.(md|sh|ts|tsx|js|jsx|json|yml|yaml|bats|py|txt|html)' "$ticket_file" 2>/dev/null \
   | sort -u \
   | grep -v '^docs/problems/' \
+  | grep -v '\.\.\.' \
   || true)
 
 shape1_missing=0
@@ -548,7 +559,7 @@ fi
 # No shape fired — fall back to the legacy KEEP / SKIP routing.
 
 if [ -z "$candidates" ]; then
-  echo "SKIP $basename — no extractable file paths (after self-reference exclusion)"
+  echo "SKIP $basename — no extractable file paths (after self-reference and elided-reference exclusion)"
   exit 2
 fi
 

--- a/packages/itil/scripts/evaluate-relevance.sh
+++ b/packages/itil/scripts/evaluate-relevance.sh
@@ -7,6 +7,7 @@
 #
 #   Shape 1 — file-no-longer-exists  (Phase 1, original)
 #   Shape 2 — ADR-shipped with `human-oversight: confirmed`  (Phase 2)
+#             CORROBORATING-ONLY — never a clean CLOSE on its own.
 #   Shape 3 — named-skill-or-feature-exists  (Phase 2)
 #   Shape 4 — self-marker-in-body (line-anchored)  (Phase 2)
 #   Shape 5 — driver-child-ticket-closed  (Phase 2)
@@ -318,6 +319,12 @@ if [ -n "$adr_refs" ]; then
   done <<< "$adr_refs"
 fi
 if [ -n "$shape2_confirmed" ]; then
+  # Corroborating-only. `human-oversight: confirmed` attests that a human
+  # ratified a DECISION (ADR-066), not that anything was built or released
+  # — treating it as delivery evidence is the marker-is-not-an-
+  # implementation-licence conflation ADR-066's 2026-05-27 amendment names.
+  # It is recorded so the cite survives (ADR-026 cumulative evidence), but
+  # the demotion below stops it closing a ticket by itself.
   record_shape "ADR-shipped-confirmed" "ADRs human-oversight-confirmed: ${shape2_confirmed}"
 fi
 
@@ -483,7 +490,27 @@ fi
 # caveat short-tag + one-line prose so the SKILL Step 4.6b template can
 # splice the **Caveat** field directly.
 
-if [ -n "$shapes" ]; then
+# Shape 2 demotion (P463 Option C, shape 2) — ratification is not
+# delivery. When shape 2 is the ONLY shape that fired, the verdict is
+# demoted from a clean CLOSE-CANDIDATE to CLOSE-CANDIDATE-WITH-CAVEAT so
+# the review-problems Step 4.6 AFK path queues it for the maintainer
+# instead of closing it silently. Measured against origin/main
+# 2026-08-30: 107/120 decision records carried the marker and 91/118
+# open/known-error tickets cited at least one, so the shape fired on ~77%
+# of the live backlog and discriminated almost nothing. P463 holds the
+# wider shape-2/shape-3 tightening pending a superseding decision; this
+# changes the verdict lane only, not the recorded mechanical check.
+#
+# Evaluated BEFORE the multi-phase block so this tag wins when both would
+# fire — the caveat field is a single structured tag per architect
+# condition C2, and "the evidence is the wrong kind" is the more
+# fundamental reason the verdict cannot be clean.
+if [ "$shapes" = "ADR-shipped-confirmed" ]; then
+  caveat_tag="ratification-is-not-delivery"
+  caveat_msg="only evidence is ADR ratification, which records a human approving a decision — not that a fix shipped; confirm the work actually landed before closing"
+fi
+
+if [ -n "$shapes" ] && [ -z "$caveat_tag" ]; then
   # Multi-phase umbrella detection: unticked checkboxes in the ticket
   # body + at least one shipped-evidence shape match. The shape match
   # itself is the "progress made" signal — unticked tasks indicate

--- a/packages/itil/scripts/test/evaluate-relevance.bats
+++ b/packages/itil/scripts/test/evaluate-relevance.bats
@@ -337,7 +337,7 @@ EOF
 #                        docs/decisions/<NNN>-*.md exists AND frontmatter has
 #                        `human-oversight: confirmed`.
 
-@test "evaluate-relevance: Phase 2 shape 2 — ADR-shipped-confirmed → CLOSE-CANDIDATE exit 0" {
+@test "evaluate-relevance: Phase 2 shape 2 alone — ADR-shipped-confirmed → CLOSE-CANDIDATE-WITH-CAVEAT (ratification is not delivery)" {
   cat > docs/decisions/037-confirmed-adr.proposed.md <<EOF
 ---
 status: "proposed"
@@ -361,9 +361,91 @@ ADR-037 was the design decision; the implementation has landed and the
 ADR is human-oversight: confirmed. Concern no longer concerning.
 EOF
   run "$SCRIPT" docs/problems/open/120-adr-confirmed.md
+  # `human-oversight: confirmed` records that a human ratified a DECISION
+  # (ADR-066) — NOT that a fix shipped. Shape 2 on its own must never
+  # produce a clean CLOSE-CANDIDATE, because review-problems Step 4.6
+  # closes those silently under AFK. It is demoted to the caveat verdict,
+  # which that same step routes to the maintainer's confirm surface.
   [ "$status" -eq 0 ]
-  [[ "$output" == "CLOSE-CANDIDATE "*"shapes: "*"ADR-shipped-confirmed"* ]]
+  [[ "${lines[0]}" == "CLOSE-CANDIDATE-WITH-CAVEAT "* ]]
+  [[ "$output" == *"ratification-is-not-delivery"* ]]
+  # The cite survives — corroborating evidence is still recorded (ADR-026).
+  [[ "$output" == *"ADR-shipped-confirmed"* ]]
   [[ "$output" == *"ADR-037"* ]]
+}
+
+@test "evaluate-relevance: Phase 2 shape 2 — corroborated by another shape → clean CLOSE-CANDIDATE (demotion is shape-2-ALONE only)" {
+  cat > docs/decisions/042-corroborated.proposed.md <<EOF
+---
+status: "proposed"
+human-oversight: confirmed
+oversight-date: 2026-05-25
+---
+
+# ADR-042: Confirmed ADR with corroborating delivery evidence
+EOF
+  git add docs/decisions/042-corroborated.proposed.md
+
+  cat > docs/problems/open/122-adr-corroborated.md <<EOF
+# Problem 122: adr-corroborated
+
+**Status**: Open
+**Reported**: $OLD_DATE
+
+## Description
+
+ADR-042 was the design decision.
+
+## Fix Released
+
+Shipped and verified.
+EOF
+  run "$SCRIPT" docs/problems/open/122-adr-corroborated.md
+  # Shape 2 + shape 4. A real delivery signal corroborates the
+  # ratification, so the verdict stays a clean CLOSE-CANDIDATE.
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "CLOSE-CANDIDATE "* ]]
+  [[ "${lines[0]}" != "CLOSE-CANDIDATE-WITH-CAVEAT "* ]]
+  [[ "$output" == *"ADR-shipped-confirmed"* ]]
+  [[ "$output" == *"self-marker-in-body"* ]]
+}
+
+@test "evaluate-relevance: caveat precedence — shape 2 alone + unticked boxes emits ratification-is-not-delivery, not multi-phase" {
+  cat > docs/decisions/043-precedence.proposed.md <<EOF
+---
+status: "proposed"
+human-oversight: confirmed
+oversight-date: 2026-05-25
+---
+
+# ADR-043: Confirmed
+EOF
+  git add docs/decisions/043-precedence.proposed.md
+
+  cat > docs/problems/open/123-precedence.md <<EOF
+# Problem 123: precedence
+
+**Status**: Open
+**Reported**: $OLD_DATE
+
+## Description
+
+ADR-043 captures the design.
+
+## Investigation Tasks
+
+- [x] Design captured
+- [ ] Implementation outstanding
+EOF
+  run "$SCRIPT" docs/problems/open/123-precedence.md
+  # Both caveat triggers match. The caveat field is a single structured
+  # tag (architect condition C2), and "the evidence is the wrong kind" is
+  # the more fundamental reason the verdict cannot be clean — so the
+  # ratification tag wins deterministically, not by statement order.
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "CLOSE-CANDIDATE-WITH-CAVEAT "* ]]
+  [[ "$output" == *"ratification-is-not-delivery"* ]]
+  [[ "$output" != *"multi-phase-mixed-progress"* ]]
 }
 
 @test "evaluate-relevance: Phase 2 shape 2 — ADR exists but NOT confirmed → no shape 2 fire" {

--- a/packages/itil/scripts/test/evaluate-relevance.bats
+++ b/packages/itil/scripts/test/evaluate-relevance.bats
@@ -853,3 +853,71 @@ EOF
   [[ "$output" == *"ADR-shipped-confirmed"* ]]
   [[ "$output" == *"self-marker-in-body"* ]]
 }
+
+# ── Phase 1 fix 4: elided prose references are not paths ─────────────────────
+#
+# Fourth member of the Phase 1 false-positive class (P180 state-suffix /
+# P244 sibling-file / P251 rename). The path regex admits `.` and `/`, so an
+# abbreviated reference inside backticks extracted as a real path, was found
+# absent, and counted as evidence the file had been deleted — concluding a
+# ticket was fixed because its prose was shortened.
+
+@test "evaluate-relevance: elided ASCII path in prose is not counted as a missing file" {
+  cat > docs/problems/open/124-elided-ascii.md <<EOF
+# Problem 124: elided-ascii
+
+**Status**: Open
+**Reported**: $OLD_DATE
+
+## Description
+
+Canonical vocabulary lives in \`packages/itil/hooks/lib/.../detectors.sh\`
+and the abbreviated form \`docs/decisions/044-....md\` is cited in prose.
+EOF
+  run "$SCRIPT" docs/problems/open/124-elided-ascii.md
+  # Neither string is a path assertion, so nothing is extracted and there is
+  # no evidence of absence. MUST NOT be a close candidate of any kind.
+  [ "$status" -eq 2 ]
+  [[ "${lines[0]}" == "SKIP "* ]]
+  [[ "$output" != *"CLOSE-CANDIDATE"* ]]
+}
+
+@test "evaluate-relevance: elided Unicode-ellipsis path in prose is not counted as a missing file" {
+  cat > docs/problems/open/125-elided-unicode.md <<EOF
+# Problem 125: elided-unicode
+
+**Status**: Open
+**Reported**: $OLD_DATE
+
+## Description
+
+See \`packages/itil/hooks/…/detectors.sh\` for the vocabulary.
+EOF
+  run "$SCRIPT" docs/problems/open/125-elided-unicode.md
+  [ "$status" -eq 2 ]
+  [[ "${lines[0]}" == "SKIP "* ]]
+  [[ "$output" != *"CLOSE-CANDIDATE"* ]]
+}
+
+@test "evaluate-relevance: elided reference alongside a real absent path does not inflate the evidence" {
+  cat > docs/problems/open/126-elided-mixed.md <<EOF
+# Problem 126: elided-mixed
+
+**Status**: Open
+**Reported**: $OLD_DATE
+
+## Description
+
+The real file \`packages/itil/scripts/deleted-thing.sh\` is gone; the
+abbreviated \`packages/itil/hooks/lib/.../detectors.sh\` is only prose.
+EOF
+  run "$SCRIPT" docs/problems/open/126-elided-mixed.md
+  # The genuinely-absent path still fires shape 1 — the filter removes the
+  # fabricated evidence, not the real evidence — and the cite names one
+  # path, not two.
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "CLOSE-CANDIDATE "* ]]
+  [[ "$output" == *"all 1 file paths absent"* ]]
+  [[ "$output" == *"deleted-thing.sh"* ]]
+  [[ "$output" != *"..."* ]]
+}

--- a/packages/itil/skills/review-problems/SKILL.md
+++ b/packages/itil/skills/review-problems/SKILL.md
@@ -295,7 +295,7 @@ For each `.open.md` / `.known-error.md` ticket aged ≥ 7 days, evaluate whether
 | Shape | Phase | Mechanical check | Empirical closes (2026-05-31) |
 |---|---|---|---|
 | 1. `file-no-longer-exists` | Phase 1 | grep ticket body for `(packages\|docs\|...)/...\.(md\|sh\|...)`; verify each via `git ls-files --error-unmatch` | 0 of 14 |
-| 2. `ADR-shipped-confirmed` | Phase 2 | grep ticket body for `ADR-NNN`; for each, verify `docs/decisions/<NNN>-*.md` exists AND frontmatter has `human-oversight: confirmed` | 8 of 14 — P012/P015/P018/P022/P033/P039/P194/P292 |
+| 2. `ADR-shipped-confirmed` **(corroborating-only)** | Phase 2 | grep ticket body for `ADR-NNN`; for each, verify `docs/decisions/<NNN>-*.md` exists AND frontmatter has `human-oversight: confirmed`. **Never a clean close on its own** — the marker records that a human ratified a DECISION (ADR-066), not that a fix shipped. Shape 2 alone demotes to `CLOSE-CANDIDATE-WITH-CAVEAT` with tag `ratification-is-not-delivery` (ADR-079 reassessment 2026-08-30) | 8 of 14 — P012/P015/P018/P022/P033/P039/P194/P292 |
 | 3. `named-skill-or-feature-exists` | Phase 2 | grep for SKILL.md / hook / agent paths + `/wr-<plugin>:<skill>` slash-command refs; verify each via `git ls-files` | 6 of 14 — P014/P034/P045/P079/P190/P289 |
 | 4. `self-marker-in-body` | Phase 2 | line-anchored grep for `Close to (Verifying\|Closed)`, `DONE 2026-`, `## Fix Released` heading, `fix shipped session`, `awaiting K→V`. Pattern MUST anchor to line-start to avoid mid-prose false-positives (architect advisory A2) | explicit in P289; contributory in P033 |
 | 5. `driver-child-ticket-closed` | Phase 2 | parse `## Related` for `P<NNN>` refs; check if any are in `docs/problems/closed/`. Suppressed when child names an unbuilt SKILL/agent path (future work, not stale; architect advisory A1) | contributory in several closes |
@@ -325,13 +325,13 @@ Exit-code routing (one verdict line per ticket on stdout):
 | Exit | Stdout prefix | Action |
 |------|--------------|--------|
 | 0 | `CLOSE-CANDIDATE <basename> — shapes: <comma-list> — <per-shape cite>; ...` | Auto-close branch (4.6b). |
-| 0 | `CLOSE-CANDIDATE-WITH-CAVEAT <basename> — shapes: <comma-list> — caveat: <short-tag>: <one-line> — cites: ...` | Surface-batch-confirm branch (4.6b-with-caveat); the caveat short-tag + one-line splices verbatim into the audit section's **Caveat** field per architect condition C2. |
+| 0 | `CLOSE-CANDIDATE-WITH-CAVEAT <basename> — shapes: <comma-list> — caveat: <short-tag>: <one-line> — cites: ...` | Surface-batch-confirm branch — **never the auto-close branch**. Under AFK, defer per 4.6a step 3: surface it, do not `git mv` it. The audit-section shape in 4.6b applies only once a maintainer has confirmed the close, and the caveat short-tag + one-line then splices verbatim into that section's **Caveat** field per architect condition C2. |
 | 1 | `KEEP <basename> — <M>/<N> paths still present` | No action; log only. |
 | 1 | `KEEP-WITH-NOTE <basename> — <note>: <evidence>` | Phase 1 false-positive class (state-suffix / sibling-file / rename) OR architect-A1 future-work disambiguation. No action; log only. |
 | 2 | `SKIP <basename> — <reason>` | No action (age gate, no Reported date, no extractable evidence). |
 | 3 | error | Log advisory; do not abort the pass — relevance-close is non-blocking per the Step 4.5 fail-soft precedent. |
 
-**Algorithm (canonical body)**: runs each of the five shape detectors over the ticket body. Multi-shape matches emit cumulatively (corroborating evidence is stronger than first-match-wins per ADR-026): the `shapes:` field carries a comma-joined list, the trailing fragment carries per-shape cites semicolon-separated. The caveat fires when at least one shape matches AND the body has any unticked checkboxes (multi-phase mixed-progress umbrella class). The verdict is intentionally conservative — tickets with no shape match AND no extractable evidence route to `SKIP`, not auto-close.
+**Algorithm (canonical body)**: runs each of the five shape detectors over the ticket body. Multi-shape matches emit cumulatively (corroborating evidence is stronger than first-match-wins per ADR-026): the `shapes:` field carries a comma-joined list, the trailing fragment carries per-shape cites semicolon-separated. Two independent triggers raise the caveat, checked in this order: (1) shape 2 is the ONLY shape that matched — tag `ratification-is-not-delivery`, because ADR ratification is not delivery evidence; (2) at least one shape matches AND the body has any unticked checkboxes — tag `multi-phase-mixed-progress`. The caveat field carries a single structured tag (architect condition C2), so trigger (1) wins when both would fire: "the evidence is the wrong kind" is the more fundamental reason the verdict cannot be clean. The verdict is intentionally conservative — tickets with no shape match AND no extractable evidence route to `SKIP`, not auto-close.
 
 **Surface-batch-confirm flow** (the methodology that produced today's 14 closes — codified for repeatable use):
 
@@ -344,7 +344,15 @@ Real-backlog smoke test 2026-05-31 against today's labeled fixtures: P012 → `C
 
 #### 4.6b. Auto-close action per CLOSE-CANDIDATE
 
-For each `CLOSE-CANDIDATE` or `CLOSE-CANDIDATE-WITH-CAVEAT` ticket, perform the following BEFORE the `git mv`:
+**Applies to clean `CLOSE-CANDIDATE` verdicts.** A `CLOSE-CANDIDATE-WITH-CAVEAT`
+verdict does NOT enter this branch on its own: under AFK it is surfaced and left
+open per 4.6a step 3, and it reaches the steps below only after a maintainer has
+confirmed the close at the next interactive review — at which point it carries
+the extra **Caveat** field noted in step 1. Closing a caveat verdict
+unattended defeats the demotion that produced it (ADR-079 reassessment
+2026-08-30, shape 2 corroborating-only).
+
+For each such ticket, perform the following BEFORE the `git mv`:
 
 1. Use the `Edit` tool to append a `## Closed as no longer relevant` section to the ticket body (cite + persist + uncertainty per ADR-026):
 
@@ -400,7 +408,7 @@ The relevance-close pass runs **unconditionally** during AFK orchestration: when
 
 **Worked example (Phase 2 surface-batch-confirm, 2026-05-31)**: 14 closes across 5 batches using shapes 2-5. Each batch surfaced via `AskUserQuestion` (≤ 5 candidates per batch); maintainer confirmed clean closes and routed caveat candidates with explicit caveat acknowledgement (e.g. P039 `shared-template-not-built`; P194 `deep-dive-bloat-remains`). All closures batched into per-batch commits per ADR-014. The 14-fixture labeled set is the regression suite (`packages/itil/scripts/test/evaluate-relevance.bats` covers each shape positive + the architect A1/A2 advisory negatives).
 
-**Cross-references**: ADR-079 (this pass's design ADR, Phase 1 + Phase 2), ADR-026 (grounding, cumulative shape cite + structured caveat field), ADR-022 + ADR-079 lifecycle extension (Open|Known Error → Closed bypassing Verifying for no-fix-needed conclusions; the Closed-row entry at `/wr-itil:manage-problem` SKILL.md line 59 names Phase 1 + Phase 2 shapes), ADR-049 (PATH shim), ADR-052 (behavioural bats at `packages/itil/scripts/test/evaluate-relevance.bats` — 33/33 GREEN), ADR-014 (batched closure commit grain per pass), ADR-044 cat 4 + P132 (mechanical-stage carve-out: ask per-batch, not per-ticket), P057 (staging trap), P346 (Phase 1 driver), P347 (Phase 2 driver).
+**Cross-references**: ADR-079 (this pass's design ADR, Phase 1 + Phase 2), ADR-026 (grounding, cumulative shape cite + structured caveat field), ADR-022 + ADR-079 lifecycle extension (Open|Known Error → Closed bypassing Verifying for no-fix-needed conclusions; the Closed-row entry at `/wr-itil:manage-problem` SKILL.md line 59 names Phase 1 + Phase 2 shapes), ADR-049 (PATH shim), ADR-052 (behavioural bats at `packages/itil/scripts/test/evaluate-relevance.bats` — 35/35 GREEN), ADR-014 (batched closure commit grain per pass), ADR-044 cat 4 + P132 (mechanical-stage carve-out: ask per-batch, not per-ticket), P057 (staging trap), P346 (Phase 1 driver), P347 (Phase 2 driver).
 
 ### 5. Rewrite `docs/problems/README.md`
 


### PR DESCRIPTION
Two defects in `evaluate-relevance.sh`, the script that decides whether a problem ticket can be auto-closed as no longer relevant. Both fabricate evidence, and both feed the lane that `/wr-itil:review-problems` Step 4.6 closes silently when running unattended.

**Read the standing note before the diff.** The first change lands inside scope that P463 explicitly holds for you. I have implemented one of the five options that ticket queues, and left the governing decision record untouched. Merging is your call.

## 1. Ratification is not delivery

Evidence shape 2 reads `human-oversight: confirmed` on a decision record as evidence that a ticket's fix has shipped. That marker records only that a human ratified a decision. P463 states the root cause in the same terms — the shape asserts citation, not resolution — and notes it fires hardest where a ticket is most valuable, because a ticket reporting that a ratified decision is unenforced cites that decision by construction.

Measured against `origin/main` on 2026-08-30: 107 of 120 decision records carry the marker (89%), and 91 of 118 open/known-error tickets cite at least one (77%). P463 records the resulting verdict rate at 76% on 2026-07-26, rising to 81% on 2026-08-21, against the ~4.2% the skill documents.

Shape 2 is now **corroborating-only**. It is still detected and still cited, and its behaviour alongside any other evidence shape is unchanged. When it is the only shape that matched, the verdict is demoted from `CLOSE-CANDIDATE` to `CLOSE-CANDIDATE-WITH-CAVEAT` under a new tag `ratification-is-not-delivery`, which Step 4.6 routes to you instead of closing.

The demotion would have been inert on its own. The Step 4.6 exit-code table pointed at a section `4.6b-with-caveat` that does not exist, and the section it actually lands on opened *"For each `CLOSE-CANDIDATE` or `CLOSE-CANDIDATE-WITH-CAVEAT` ticket ... BEFORE the `git mv`"* — so an unattended agent would have closed the demoted verdicts anyway. The table row now routes caveat verdicts to 4.6a step 3, and 4.6b scopes itself to clean verdicts. The risk scorer caught this, not me.

## 2. An elided path in prose is not a deleted file

Shape 1 extracts candidate paths with a character class admitting `.` and `/`, so an abbreviated reference inside backticks — `packages/itil/hooks/lib/.../detectors.sh`, or `docs/decisions/044-....md` — extracted as a real path, was found absent, and counted as evidence the file had been deleted. A ticket could be judged fixed because its prose had been shortened. Before the fix, a ticket containing only those two references produced `CLOSE-CANDIDATE ... all 2 file paths absent`.

Fourth member of the Phase 1 false-positive class alongside P180, P244 and P251. One `grep -v` in the candidate pipeline; when every candidate is filtered the verdict falls through to `SKIP`, never to a close. This one needs no decision — it is a plain defect in shape 1's extraction, outside the scope P463 holds.

Only the ASCII form needed a filter. I first added one for the Unicode `…` too, but the check showed that case already passing against the old script — `…` falls outside the extraction character class and never matched. The dead filter is gone and the regression case stays, so it remains true.

## Where this sits against P463

P463 is a Known Error at priority 20 with the root cause confirmed, and it queues five options for you rather than guessing. This branch is **Option C for shape 2 only** — keep the searches as they are, but never let this signal close a ticket silently. Option C leaves the recorded mechanical check untouched and changes only which lane the verdict takes.

What this branch does **not** do:

- Shape 3 (`named-skill-or-feature-exists`) is untouched, though P463 records the same inversion there.
- Option A (scope the greps to a fix-evidence region) is not attempted. The architect's advisory lean recorded in P463 is a composed A + C; this is the C half.
- It does not reduce the caveated-verdict rate P463 measured at 61 of 80 on 2026-07-26. Those carry the `multi-phase-mixed-progress` caveat and are an Option A problem.
- **`docs/decisions/079-*.md` is deliberately unedited.** P463 holds implementation pending a decision superseding ADR-079 in part.

I am not asserting that hold is discharged, and if you pick a different option the code here is small enough to drop. I first drafted this branch with an ADR-079 amendment, on two premises that both turned out to be wrong: that the reassessment trigger had fired (it counts false-positive *closes*, and the bad verdicts on record were caught in review rather than closed), and that amending the record was mine to do. It is worth noting what ADR-079 actually is, since it is the same distinction this PR turns on: a record with `status: "proposed"` carrying a confirmed-oversight marker. The amendment is gone.

## Verification

- 38/38 in `evaluate-relevance.bats`, up from 33. Six new or rewritten cases.
- Four of the six fail against the previous logic and pass against the new, verified by stashing the script and re-running. The corroboration and Unicode cases pass against both by design — they pin behaviour that must not change.
- The wider suite has at least five pre-existing failures (Codex SessionStart dispatch, risk-scorer dispatch, story-map rendering). All five reproduce on a clean `origin/main` worktree and are unrelated to these files. The suite did not run to completion inside a 10-minute budget, so that count is from a partial run.
- Reviewed by `wr-architect:agent` (four findings raised, all addressed), `wr-jtbd:agent` (aligned), and `wr-risk-scorer:pipeline` (4/25 Low per commit, risk-reducing). The architect cleared an ADR-079 amendment, but I had not shown it P463; that clearance is why the amendment existed, and dropping it supersedes the advice.

## Follow-on, not done here

The `review-problems` promptfoo eval has no case covering Step 4.6 verdict routing, so the prose changed above has no paired assertion.

Raised unattended from an AFK loop. Please review the substance rather than taking the reviewer verdicts above at face value.
